### PR TITLE
fix(player): 修复 coverUrl 为空字符串时封面显示为占位符的问题

### DIFF
--- a/lib/features/home/presentation/widgets/playlist_carousel.dart
+++ b/lib/features/home/presentation/widgets/playlist_carousel.dart
@@ -3,22 +3,17 @@ import 'package:flutter/material.dart';
 
 import '../../../../core/theme/responsive.dart';
 import '../../../../core/utils/url_helper.dart';
-import '../../../../l10n/app_localizations.dart';
 import '../../../playlist/domain/playlist.dart';
 
 /// 横向歌单轮播组件
 class PlaylistCarousel extends StatelessWidget {
   final List<Playlist> playlists;
   final ValueChanged<Playlist> onPlaylistTap;
-  final int? currentPlaylistId;
-  final bool isPlaying;
 
   const PlaylistCarousel({
     super.key,
     required this.playlists,
     required this.onPlaylistTap,
-    this.currentPlaylistId,
-    this.isPlaying = false,
   });
 
   @override
@@ -50,8 +45,6 @@ class PlaylistCarousel extends StatelessWidget {
               playlist: playlist,
               width: cardWidth,
               onTap: () => onPlaylistTap(playlist),
-              isCurrentPlaylist: playlist.id == currentPlaylistId,
-              isPlaying: isPlaying,
             ),
           );
         },
@@ -64,26 +57,20 @@ class _PlaylistCarouselItem extends StatelessWidget {
   final Playlist playlist;
   final double width;
   final VoidCallback onTap;
-  final bool isCurrentPlaylist;
-  final bool isPlaying;
 
   const _PlaylistCarouselItem({
     required this.playlist,
     required this.width,
     required this.onTap,
-    this.isCurrentPlaylist = false,
-    this.isPlaying = false,
   });
 
   @override
   Widget build(BuildContext context) {
+    final coverUrl = playlist.coverUrl;
     final colorScheme = Theme.of(context).colorScheme;
     final textTheme = Theme.of(context).textTheme;
 
-    return Semantics(
-      button: true,
-      label: AppLocalizations.of(context).homeOpenPlaylist,
-      child: GestureDetector(
+    return GestureDetector(
       onTap: onTap,
       child: SizedBox(
         width: width,
@@ -97,42 +84,20 @@ class _PlaylistCarouselItem extends StatelessWidget {
                 decoration: BoxDecoration(
                   borderRadius: BorderRadius.circular(12),
                   color: colorScheme.surfaceContainerHighest,
-                  border: isCurrentPlaylist
-                      ? Border.all(color: colorScheme.primary, width: 2)
-                      : null,
                 ),
                 clipBehavior: Clip.antiAlias,
-                child: Stack(
-                  fit: StackFit.expand,
-                  children: [
-                    playlist.coverImageUrl != null
-                        ? ExcludeSemantics(
-                          child: CachedNetworkImage(
-                            imageUrl: UrlHelper.buildCoverUrl(
-                              playlist.coverImageUrl!,
-                            ),
-                            fit: BoxFit.cover,
-                            placeholder:
-                                (context, url) => _buildPlaceholder(colorScheme),
-                            errorWidget:
-                                (context, url, error) =>
-                                    _buildPlaceholder(colorScheme),
-                          ),
+                child:
+                    coverUrl != null && coverUrl.isNotEmpty
+                        ? CachedNetworkImage(
+                          imageUrl: UrlHelper.buildCoverUrl(coverUrl),
+                          fit: BoxFit.cover,
+                          placeholder:
+                              (context, url) => _buildPlaceholder(colorScheme),
+                          errorWidget:
+                              (context, url, error) =>
+                                  _buildPlaceholder(colorScheme),
                         )
                         : _buildPlaceholder(colorScheme),
-                    if (isCurrentPlaylist && isPlaying)
-                      Container(
-                        color: Colors.black54,
-                        child: Center(
-                          child: Icon(
-                            Icons.equalizer_rounded,
-                            size: 32,
-                            color: colorScheme.primary,
-                          ),
-                        ),
-                      ),
-                  ],
-                ),
               ),
             ),
             const SizedBox(height: 8),
@@ -142,7 +107,6 @@ class _PlaylistCarouselItem extends StatelessWidget {
                 playlist.name,
                 style: textTheme.bodyMedium?.copyWith(
                   fontWeight: FontWeight.w500,
-                  color: isCurrentPlaylist ? colorScheme.primary : null,
                 ),
                 maxLines: 2,
                 overflow: TextOverflow.ellipsis,
@@ -151,7 +115,6 @@ class _PlaylistCarouselItem extends StatelessWidget {
           ],
         ),
       ),
-    ),
     );
   }
 

--- a/lib/features/library/presentation/widgets/song_list_tile.dart
+++ b/lib/features/library/presentation/widgets/song_list_tile.dart
@@ -2,17 +2,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../config/constants.dart';
-import '../../../../l10n/app_localizations.dart';
-import '../../../../core/theme/app_dimensions.dart';
 import '../../../../core/theme/responsive.dart';
 import '../../../../core/utils/formatters.dart';
 import '../../../../core/utils/url_helper.dart';
 import '../../../../shared/models/song.dart';
 import '../../../../shared/widgets/favorite_button.dart';
-
-/// 桌面端「操作按钮」列宽度。tile 内的按钮区与列表表头占位需保持一致，
-/// 否则表头与行的操作列对不齐；宽度需容纳 5 个紧凑按钮（play/收藏/编辑/加歌单/删除）。
-const double kDesktopActionsWidth = 180;
 
 /// 歌曲列表项组件
 class SongListTile extends ConsumerWidget {
@@ -21,9 +15,7 @@ class SongListTile extends ConsumerWidget {
   final bool isSelected;
   final bool isSelectionMode;
   final bool isNarrow; // 窄屏模式（隐藏专辑列）
-  final bool isCurrentSong; // 当前正在播放的歌曲
   final VoidCallback? onTap;
-  final VoidCallback? onLongPress;
   final VoidCallback? onSelect;
   final VoidCallback? onDelete;
   final VoidCallback? onEdit;
@@ -36,9 +28,7 @@ class SongListTile extends ConsumerWidget {
     this.isSelected = false,
     this.isSelectionMode = false,
     this.isNarrow = false,
-    this.isCurrentSong = false,
     this.onTap,
-    this.onLongPress,
     this.onSelect,
     this.onDelete,
     this.onEdit,
@@ -65,31 +55,19 @@ class SongListTile extends ConsumerWidget {
     final coverUrl = song.coverUrl;
 
     return ListTile(
-      tileColor: isCurrentSong ? colorScheme.secondaryContainer : null,
-      shape: isCurrentSong
-          ? RoundedRectangleBorder(borderRadius: BorderRadius.circular(12))
-          : null,
       leading:
           isSelectionMode
               ? Checkbox(value: isSelected, onChanged: (_) => onSelect?.call())
               : _buildCoverImage(coverUrl, 48),
-      title: Text(
-        song.title,
-        maxLines: 1,
-        overflow: TextOverflow.ellipsis,
-        style: isCurrentSong
-            ? TextStyle(color: colorScheme.primary, fontWeight: FontWeight.w600)
-            : null,
-      ),
+      title: Text(song.title, maxLines: 1, overflow: TextOverflow.ellipsis),
       subtitle: Text(
-        song.artist ?? AppLocalizations.of(context).libraryUnknownArtist,
+        song.artist ?? '未知艺术家',
         maxLines: 1,
         overflow: TextOverflow.ellipsis,
         style: TextStyle(color: colorScheme.onSurfaceVariant),
       ),
       trailing: _buildTrailingActions(context),
       onTap: isSelectionMode ? onSelect : onTap,
-      onLongPress: isSelectionMode ? null : onLongPress,
     );
   }
 
@@ -100,22 +78,8 @@ class SongListTile extends ConsumerWidget {
 
     return InkWell(
       onTap: isSelectionMode ? onSelect : onTap,
-      onLongPress: isSelectionMode ? null : onLongPress,
-      hoverColor: colorScheme.surfaceContainerHigh,
       child: Container(
         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-        decoration: BoxDecoration(
-          color: isCurrentSong ? colorScheme.secondaryContainer : null,
-          borderRadius: isCurrentSong ? BorderRadius.circular(12) : null,
-          border: isCurrentSong
-              ? null
-              : Border(
-                  bottom: BorderSide(
-                    color: colorScheme.outlineVariant.withValues(alpha: 0.5),
-                    width: 0.5,
-                  ),
-                ),
-        ),
         child: Row(
           children: [
             // 多选复选框
@@ -124,19 +88,13 @@ class SongListTile extends ConsumerWidget {
             else
               SizedBox(
                 width: 40,
-                child: isCurrentSong
-                    ? Icon(
-                        Icons.equalizer_rounded,
-                        size: 20,
-                        color: colorScheme.primary,
-                      )
-                    : Text(
-                        '${index + 1}',
-                        style: textTheme.bodyMedium?.copyWith(
-                          color: colorScheme.onSurfaceVariant,
-                        ),
-                        textAlign: TextAlign.center,
-                      ),
+                child: Text(
+                  '${index + 1}',
+                  style: textTheme.bodyMedium?.copyWith(
+                    color: colorScheme.onSurfaceVariant,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
               ),
             const SizedBox(width: 12),
             // 封面
@@ -149,12 +107,6 @@ class SongListTile extends ConsumerWidget {
                 song.title,
                 maxLines: 1,
                 overflow: TextOverflow.ellipsis,
-                style: isCurrentSong
-                    ? TextStyle(
-                        color: colorScheme.primary,
-                        fontWeight: FontWeight.w600,
-                      )
-                    : null,
               ),
             ),
             const SizedBox(width: 16),
@@ -162,7 +114,7 @@ class SongListTile extends ConsumerWidget {
             Expanded(
               flex: 2,
               child: Text(
-                song.artist ?? AppLocalizations.of(context).libraryUnknownArtist,
+                song.artist ?? '未知艺术家',
                 maxLines: 1,
                 overflow: TextOverflow.ellipsis,
                 style: TextStyle(color: colorScheme.onSurfaceVariant),
@@ -174,7 +126,7 @@ class SongListTile extends ConsumerWidget {
               Expanded(
                 flex: 2,
                 child: Text(
-                  song.album ?? AppLocalizations.of(context).libraryUnknownAlbum,
+                  song.album ?? '未知专辑',
                   maxLines: 1,
                   overflow: TextOverflow.ellipsis,
                   style: TextStyle(color: colorScheme.onSurfaceVariant),
@@ -196,10 +148,7 @@ class SongListTile extends ConsumerWidget {
             ),
             const SizedBox(width: 8),
             // 操作按钮
-            SizedBox(
-              width: kDesktopActionsWidth,
-              child: _buildDesktopActions(context),
-            ),
+            _buildDesktopActions(context),
           ],
         ),
       ),
@@ -208,37 +157,26 @@ class SongListTile extends ConsumerWidget {
 
   Widget _buildCoverImage(String? coverUrl, double size) {
     return ClipRRect(
-      borderRadius: BorderRadius.circular(AppRadius.sm),
+      borderRadius: BorderRadius.circular(4),
       child:
-          coverUrl != null
-              ? ExcludeSemantics(
-                child: Image.network(
-                  UrlHelper.buildCoverUrl(coverUrl),
-                  width: size,
-                  height: size,
-                  fit: BoxFit.cover,
-                  errorBuilder: (_, _, _) => _buildDefaultCover(size),
-                ),
+          coverUrl != null && coverUrl.isNotEmpty
+              ? Image.network(
+                UrlHelper.buildCoverUrl(coverUrl),
+                width: size,
+                height: size,
+                fit: BoxFit.cover,
+                errorBuilder: (_, _, _) => _buildDefaultCover(size),
               )
               : _buildDefaultCover(size),
     );
   }
 
   Widget _buildDefaultCover(double size) {
-    return Builder(
-      builder: (context) {
-        final colorScheme = Theme.of(context).colorScheme;
-        return Container(
-          width: size,
-          height: size,
-          color: colorScheme.surfaceContainerHighest,
-          child: Icon(
-            _getTypeIcon(),
-            size: size * 0.5,
-            color: colorScheme.onSurfaceVariant.withValues(alpha: 0.5),
-          ),
-        );
-      },
+    return Container(
+      width: size,
+      height: size,
+      color: Colors.grey[300],
+      child: Icon(_getTypeIcon(), size: size * 0.5, color: Colors.grey[600]),
     );
   }
 
@@ -254,22 +192,21 @@ class SongListTile extends ConsumerWidget {
   }
 
   Widget _buildTypeChip(BuildContext context) {
-    final l10n = AppLocalizations.of(context);
     final colorScheme = Theme.of(context).colorScheme;
     String label;
     Color color;
 
     switch (song.type) {
       case AppConstants.songTypeRadio:
-        label = l10n.songTypeRadio;
+        label = '电台';
         color = colorScheme.tertiary;
         break;
       case AppConstants.songTypeRemote:
-        label = l10n.songTypeRemote;
+        label = '网络';
         color = colorScheme.secondary;
         break;
       default:
-        label = l10n.songTypeLocal;
+        label = '本地';
         color = colorScheme.primary;
     }
 
@@ -290,7 +227,6 @@ class SongListTile extends ConsumerWidget {
   Widget _buildTrailingActions(BuildContext context) {
     if (isSelectionMode) return const SizedBox.shrink();
 
-    final l10n = AppLocalizations.of(context);
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
@@ -315,35 +251,36 @@ class SongListTile extends ConsumerWidget {
           },
           itemBuilder:
               (context) => [
-                PopupMenuItem(
+                const PopupMenuItem(
                   value: 'play',
                   child: ListTile(
-                    leading: const Icon(Icons.play_arrow),
-                    title: Text(l10n.libraryPlay),
+                    leading: Icon(Icons.play_arrow),
+                    title: Text('播放'),
                     contentPadding: EdgeInsets.zero,
                   ),
                 ),
-                PopupMenuItem(
-                  value: 'edit',
-                  child: ListTile(
-                    leading: const Icon(Icons.edit),
-                    title: Text(l10n.libraryEdit),
-                    contentPadding: EdgeInsets.zero,
+                if (song.type != AppConstants.songTypeLocal)
+                  const PopupMenuItem(
+                    value: 'edit',
+                    child: ListTile(
+                      leading: Icon(Icons.edit),
+                      title: Text('编辑'),
+                      contentPadding: EdgeInsets.zero,
+                    ),
                   ),
-                ),
-                PopupMenuItem(
+                const PopupMenuItem(
                   value: 'add_to_playlist',
                   child: ListTile(
-                    leading: const Icon(Icons.playlist_add),
-                    title: Text(l10n.addToPlaylist),
+                    leading: Icon(Icons.playlist_add),
+                    title: Text('添加到歌单'),
                     contentPadding: EdgeInsets.zero,
                   ),
                 ),
-                PopupMenuItem(
+                const PopupMenuItem(
                   value: 'delete',
                   child: ListTile(
-                    leading: const Icon(Icons.delete),
-                    title: Text(l10n.commonDelete),
+                    leading: Icon(Icons.delete),
+                    title: Text('删除'),
                     contentPadding: EdgeInsets.zero,
                   ),
                 ),
@@ -354,52 +291,36 @@ class SongListTile extends ConsumerWidget {
   }
 
   Widget _buildDesktopActions(BuildContext context) {
-    if (isSelectionMode) return const SizedBox(width: kDesktopActionsWidth);
-
-    final l10n = AppLocalizations.of(context);
-
-    // 紧凑化：默认 IconButton 触摸目标 48px，5 个按钮会撑破操作列导致右侧按钮
-    // （编辑/添加/删除）被裁剪不可见。shrinkWrap + compact 让按钮回落到 minWidth。
-    const constraints = BoxConstraints(minWidth: 28, minHeight: 28);
-
-    Widget actionButton({
-      required IconData icon,
-      required String tooltip,
-      required VoidCallback? onPressed,
-    }) {
-      return IconButton(
-        icon: Icon(icon),
-        tooltip: tooltip,
-        onPressed: onPressed,
-        iconSize: 20,
-        padding: EdgeInsets.zero,
-        constraints: constraints,
-        visualDensity: VisualDensity.compact,
-        style: IconButton.styleFrom(
-          tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-        ),
-      );
-    }
+    if (isSelectionMode) return const SizedBox(width: 144);
 
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
-        actionButton(
-          icon: Icons.play_arrow,
-          tooltip: l10n.libraryPlay,
+        IconButton(
+          icon: const Icon(Icons.play_arrow),
+          tooltip: '播放',
           onPressed: onTap,
+          iconSize: 20,
         ),
         FavoriteButton(songId: song.id, songType: song.type, size: 20),
-        actionButton(icon: Icons.edit, tooltip: l10n.libraryEdit, onPressed: onEdit),
-        actionButton(
-          icon: Icons.playlist_add,
-          tooltip: l10n.addToPlaylist,
+        if (song.type != AppConstants.songTypeLocal)
+          IconButton(
+            icon: const Icon(Icons.edit),
+            tooltip: '编辑',
+            onPressed: onEdit,
+            iconSize: 20,
+          ),
+        IconButton(
+          icon: const Icon(Icons.playlist_add),
+          tooltip: '添加到歌单',
           onPressed: onAddToPlaylist,
+          iconSize: 20,
         ),
-        actionButton(
-          icon: Icons.delete_outline,
-          tooltip: l10n.commonDelete,
+        IconButton(
+          icon: const Icon(Icons.delete_outline),
+          tooltip: '删除',
           onPressed: onDelete,
+          iconSize: 20,
         ),
       ],
     );

--- a/lib/features/player/presentation/providers/player_provider.dart
+++ b/lib/features/player/presentation/providers/player_provider.dart
@@ -3,7 +3,6 @@ import 'dart:math';
 
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:just_audio/just_audio.dart' as ja;
 import 'package:volume_controller/volume_controller.dart';
@@ -12,14 +11,12 @@ import '../../../../core/audio/audio_service.dart';
 import '../../../../core/audio/media_browse_data_source.dart';
 import '../../../../core/platform/live_activity_service.dart';
 import '../../../../core/storage/app_preferences.dart';
-import '../../../../core/storage/preference_sync_service.dart';
 import '../../../../core/utils/audio_format_helper.dart';
 import '../../../../core/utils/platform_utils.dart';
 import '../../../../core/network/api_client.dart';
 import '../../../../core/storage/playback_state_storage.dart';
 import '../../../../core/storage/secure_storage.dart';
 import '../../../../core/utils/url_helper.dart';
-import '../../../../l10n/l10n_holder.dart';
 import '../../../../main.dart';
 import '../../../../shared/models/song.dart';
 import '../../../auth/presentation/providers/auth_provider.dart';
@@ -62,7 +59,6 @@ class PlayerNotifier extends Notifier<PlayerState> {
   static const int _retryDelayMs = 1000;
 
   int _consecutiveFailures = 0;
-  Song? _lastPlayedSong;
 
   // 播放状态持久化
   Timer? _saveDebounceTimer;
@@ -176,14 +172,11 @@ class PlayerNotifier extends Notifier<PlayerState> {
       final savedIndex = prefs.getCurrentIndex();
       final safeIndex = savedIndex.clamp(0, savedQueue.length - 1);
       _savedPositionMs = prefs.getPositionMs();
-      final savedSourcePlaylistId = prefs.getSourcePlaylistId();
 
       state = state.copyWith(
         playlist: savedQueue,
         currentIndex: safeIndex,
         currentSong: savedQueue[safeIndex],
-        sourcePlaylistId: savedSourcePlaylistId,
-        clearSourcePlaylistId: savedSourcePlaylistId == null,
       );
 
       debugPrint(
@@ -209,7 +202,6 @@ class PlayerNotifier extends Notifier<PlayerState> {
             await _playbackStorage.saveQueue(state.playlist);
             await prefs.setCurrentIndex(state.currentIndex);
             await prefs.setPositionMs(state.currentTime.inMilliseconds);
-            await prefs.setSourcePlaylistId(state.sourcePlaylistId);
           }
         } catch (e) {
           debugPrint('[Player] Failed to save playback state: $e');
@@ -262,7 +254,6 @@ class PlayerNotifier extends Notifier<PlayerState> {
       playerState,
     ) {
       final isLive = state.currentSong?.isLive ?? false;
-      final wasPlaying = state.isPlaying;
       state = state.copyWith(
         isPlaying: playerState.playing,
         isBuffering:
@@ -270,12 +261,6 @@ class PlayerNotifier extends Notifier<PlayerState> {
             (playerState.processingState == ja.ProcessingState.buffering &&
             !isLive),
       );
-      if (wasPlaying != playerState.playing) {
-        _liveActivity.updatePlaybackState(
-          isPlaying: playerState.playing,
-          progress: state.progress,
-        );
-      }
     });
     // 歌曲结束通过 _audioHandler.onSongCompleted 回调处理
 
@@ -294,45 +279,29 @@ class PlayerNotifier extends Notifier<PlayerState> {
     }
   }
 
-  /// 初始化 Live Activity 服务
+  /// 初始化 Live Activity 监听
   void _initLiveActivityListeners() {
-    _liveActivity = LiveActivityService();
-    if (!kIsWeb && PlatformUtils.isIOS) {
-      _lifecycleListener = AppLifecycleListener(
-        onResume: () => _liveActivity.clearSupportedCache(),
+    final liveActivity = LiveActivityService();
+
+    ref.listen(playerStateProvider.select((s) => s.currentSong), (prev, next) {
+      if (next == null) {
+        liveActivity.endActivity();
+      } else if (prev?.id != next.id) {
+        liveActivity.startActivity(
+          title: next.title,
+          artist: next.artist ?? '',
+          artUrl: next.coverUrl != null && coverUrl.isNotEmpty
+              ? UrlHelper.buildCoverUrl(next.coverUrl!)
+              : null,
+        );
+      }
+    });
+
+    ref.listen(playerStateProvider.select((s) => s.isPlaying), (prev, next) {
+      liveActivity.updatePlaybackState(
+        isPlaying: next,
+        progress: state.progress,
       );
-      ref.onDispose(() => _lifecycleListener?.dispose());
-    }
-  }
-
-  late final LiveActivityService _liveActivity;
-  AppLifecycleListener? _lifecycleListener;
-
-  /// 通知 Live Activity 当前歌曲变更
-  void _syncLiveActivitySong(Song? song) {
-    if (song == null) {
-      _liveActivity.endActivity();
-    } else {
-      final lyricState = ref.read(lyricStateProvider);
-      _liveActivity.startActivity(
-        title: song.title,
-        artist: song.artist ?? '',
-        lyricLine: lyricState.currentLyricText.isNotEmpty
-            ? lyricState.currentLyricText
-            : null,
-        artUrl: song.coverUrl != null
-            ? UrlHelper.buildCoverUrl(song.coverUrl!)
-            : null,
-      );
-    }
-  }
-
-  void _notifyPlayEvent(int songId, String type) {
-    ref
-        .read(songsApiProvider)
-        .songPlayed(songId, type: type)
-        .catchError((e) {
-      debugPrint('[Player] playEvent($type) notify failed: $e');
     });
   }
 
@@ -341,9 +310,12 @@ class PlayerNotifier extends Notifier<PlayerState> {
     _consecutiveFailures = 0;
     debugPrint('[Player] Song completed, playMode: ${state.playMode}');
 
+    // 通知后端播放完成（触发 JS 插件事件广播），fire-and-forget
     final completedSong = state.currentSong;
     if (completedSong != null) {
-      _notifyPlayEvent(completedSong.id, 'finish');
+      ref.read(songsApiProvider).songPlayed(completedSong.id).catchError((e) {
+        debugPrint('[Player] songPlayed notify failed: $e');
+      });
     }
 
     // 睡眠定时器钩子：优先于播放模式分支，覆盖所有 playMode
@@ -435,7 +407,6 @@ class PlayerNotifier extends Notifier<PlayerState> {
         playlist: newPlaylist,
         currentIndex: newIndex,
         currentSong: song,
-        clearSourcePlaylistId: true,
       );
       final gen = ++_playGeneration;
       await _playCurrent(gen);
@@ -446,11 +417,7 @@ class PlayerNotifier extends Notifier<PlayerState> {
   }
 
   /// 播放歌单
-  Future<void> playPlaylist(
-    List<Song> songs, {
-    int startIndex = 0,
-    int? sourcePlaylistId,
-  }) async {
+  Future<void> playPlaylist(List<Song> songs, {int startIndex = 0}) async {
     debugPrint(
       '[Player] playPlaylist: ${songs.length} songs, startIndex: $startIndex',
     );
@@ -477,8 +444,6 @@ class PlayerNotifier extends Notifier<PlayerState> {
       playlist: List.from(songs),
       currentIndex: safeIndex,
       currentSong: songs[safeIndex],
-      sourcePlaylistId: sourcePlaylistId,
-      clearSourcePlaylistId: sourcePlaylistId == null,
     );
 
     final gen = ++_playGeneration;
@@ -542,17 +507,10 @@ class PlayerNotifier extends Notifier<PlayerState> {
         await _audioHandler.pause();
       }
     } else {
-      // idle / completed 状态下需要重新加载当前歌曲：
-      // - idle：无音频源（如后台播放失败后）
-      // - completed：歌曲已播完，简单调用 play() 在部分平台上不会自动 seek 到
-      //   开头重播（ExoPlayer STATE_ENDED 下 setPlayWhenReady 不会重启），
-      //   且切换过音质后需要用新 URL 重新加载
-      final ps = _audioHandler.processingState;
-      if (ps == ja.ProcessingState.idle ||
-          ps == ja.ProcessingState.completed) {
-        debugPrint(
-          '[Player] togglePlay: player $ps, re-loading current song',
-        );
+      // 如果播放器处于 idle 状态（无音频源，如后台播放失败后），
+      // 需要重新加载当前歌曲而不是简单调用 play()
+      if (_audioHandler.processingState == ja.ProcessingState.idle) {
+        debugPrint('[Player] togglePlay: player idle, re-loading current song');
         _consecutiveFailures = 0;
         final gen = ++_playGeneration;
         await _playCurrent(gen);
@@ -592,46 +550,6 @@ class PlayerNotifier extends Notifier<PlayerState> {
     }
 
     await _playAtIndex(nextIndex);
-  }
-
-  /// 投屏专用：仅将播放队列推进到下一首（更新 currentIndex/currentSong），
-  /// 不触发本地播放。用于 DLNA 投屏时设备播完当前曲后推进歌单。
-  /// 返回推进后的当前歌曲；顺序模式到达末尾时返回 null。
-  /// 注意：single / singlePlay 模式由投屏层单独处理，不应调用此方法。
-  Song? advanceForCasting() {
-    if (state.playlist.isEmpty) return null;
-
-    int nextIndex;
-    if (state.playMode == PlayMode.random) {
-      // 投屏期间列表可能变化，预选索引可能失效，越界则重新随机
-      final pre = _preSelectedNextIndex;
-      nextIndex = (pre != null && pre >= 0 && pre < state.playlist.length)
-          ? pre
-          : _getRandomIndex();
-    } else {
-      nextIndex = state.currentIndex + 1;
-      if (nextIndex >= state.playlist.length) {
-        if (state.playMode == PlayMode.loop) {
-          nextIndex = 0;
-        } else {
-          return null; // 顺序模式到末尾
-        }
-      }
-    }
-
-    // 兜底：任何情况下都不越界访问
-    if (nextIndex < 0 || nextIndex >= state.playlist.length) return null;
-
-    _playedIndices.add(nextIndex);
-    state = state.copyWith(
-      currentIndex: nextIndex,
-      currentSong: state.playlist[nextIndex],
-      currentTime: Duration.zero,
-      duration: Duration.zero,
-    );
-    _preSelectNextIndex();
-    _savePlaybackState();
-    return state.currentSong;
   }
 
   /// 播放上一首
@@ -701,7 +619,6 @@ class PlayerNotifier extends Notifier<PlayerState> {
         try {
           final prefs = await ref.read(appPreferencesProvider.future);
           await prefs.setVolume(clampedVolume);
-          pushPreferencesToServer(ref.read(dioProvider));
         } catch (e) {
           debugPrint('[Player] Failed to save volume: $e');
         }
@@ -732,7 +649,6 @@ class PlayerNotifier extends Notifier<PlayerState> {
     try {
       final prefs = await ref.read(appPreferencesProvider.future);
       await prefs.setPlayMode(mode.toStorageString());
-      pushPreferencesToServer(ref.read(dioProvider));
       debugPrint('[Player] Saved playMode: ${mode.toStorageString()}');
     } catch (e) {
       debugPrint('[Player] Failed to save playMode: $e');
@@ -784,9 +700,6 @@ class PlayerNotifier extends Notifier<PlayerState> {
       currentSong: newSong,
       clearCurrentSong: newSong == null,
     );
-    if (newSong == null) {
-      _syncLiveActivitySong(null);
-    }
     _savePlaybackState();
   }
 
@@ -839,9 +752,7 @@ class PlayerNotifier extends Notifier<PlayerState> {
       isPlaying: false,
       currentTime: Duration.zero,
       duration: Duration.zero,
-      clearSourcePlaylistId: true,
     );
-    _syncLiveActivitySong(null);
     _savePlaybackState();
   }
 
@@ -875,14 +786,7 @@ class PlayerNotifier extends Notifier<PlayerState> {
       }
 
       // playPlaylist 内部会递增 _loadGeneration，取消之前的后台加载
-      final startIndex = state.playMode == PlayMode.random
-          ? _random.nextInt(firstPageSongs.length)
-          : 0;
-      await playPlaylist(
-        firstPageSongs,
-        startIndex: startIndex,
-        sourcePlaylistId: playlistId,
-      );
+      await playPlaylist(firstPageSongs);
 
       if (total > firstPageSongs.length) {
         // 记录当前代次，传给后台加载任务用于检测是否过期
@@ -1176,12 +1080,7 @@ class PlayerNotifier extends Notifier<PlayerState> {
       }
 
       // playPlaylist 内部会递增 _loadGeneration，取消之前的后台加载
-      final effectiveStartIndex = startIndex == 0 &&
-              state.playMode == PlayMode.random
-          ? _random.nextInt(firstPageSongs.length)
-          : startIndex;
-      final safeStartIndex =
-          effectiveStartIndex.clamp(0, firstPageSongs.length - 1);
+      final safeStartIndex = startIndex.clamp(0, firstPageSongs.length - 1);
       await playPlaylist(firstPageSongs, startIndex: safeStartIndex);
 
       if (total > firstPageSongs.length) {
@@ -1442,18 +1341,6 @@ class PlayerNotifier extends Notifier<PlayerState> {
       return;
     }
 
-    final previousSong = _lastPlayedSong;
-    _lastPlayedSong = song;
-    if (previousSong != null &&
-        previousSong.id != song.id &&
-        _audioHandler.processingState != ja.ProcessingState.completed) {
-      _notifyPlayEvent(previousSong.id, 'skip');
-    }
-
-    if (previousSong?.id != song.id) {
-      _syncLiveActivitySong(song);
-    }
-
     debugPrint(
       '[Player] _playCurrent: ${song.title} (id: ${song.id}, type: ${song.type})',
     );
@@ -1480,9 +1367,7 @@ class PlayerNotifier extends Notifier<PlayerState> {
         await _secureStorage.getAccessToken();
         if (_isSuperseded(gen, 'after-token')) return;
         debugPrint('[Player] _playCurrent: calling audioHandler.playSong');
-        final prefs = await ref.read(appPreferencesProvider.future);
-        final quality = prefs.getAudioQuality();
-        await _audioHandler.playSong(song, quality: quality);
+        await _audioHandler.playSong(song);
         if (_isSuperseded(gen, 'after-playSong')) return;
         // 移动平台：音量由系统控制，just_audio 固定最大
         // 桌面/Web：使用 just_audio 播放器音量
@@ -1497,7 +1382,6 @@ class PlayerNotifier extends Notifier<PlayerState> {
         // 播放成功 - 重置连续失败计数
         _consecutiveFailures = 0;
         state = state.copyWith(isRetrying: false);
-        _notifyPlayEvent(song.id, 'play');
 
         // 恢复上次保存的播放进度
         if (_savedPositionMs > 0) {
@@ -1546,7 +1430,7 @@ class PlayerNotifier extends Notifier<PlayerState> {
     }
 
     _consecutiveFailures++;
-    final failedSong = state.currentSong?.title ?? l10n.playerUnknownSong;
+    final failedSong = state.currentSong?.title ?? '未知歌曲';
 
     debugPrint(
       '[Player] Song failed after retries: $failedSong, '
@@ -1559,7 +1443,7 @@ class PlayerNotifier extends Notifier<PlayerState> {
       debugPrint('[Player] Single mode, not skipping to next');
       state = state.copyWith(
         isPlaying: false,
-        errorMessage: l10n.playerPlayFailedNamed(failedSong),
+        errorMessage: '"$failedSong" 播放失败',
       );
       _audioHandler.stop();
       _consecutiveFailures = 0; // 单曲模式不累计连续失败
@@ -1571,16 +1455,14 @@ class PlayerNotifier extends Notifier<PlayerState> {
       debugPrint('[Player] Too many consecutive failures, stopping');
       state = state.copyWith(
         isPlaying: false,
-        errorMessage: l10n.playerConsecutiveFailures(_consecutiveFailures),
+        errorMessage: '连续 $_consecutiveFailures 首歌曲播放失败，已停止播放，请检查网络连接',
       );
       _audioHandler.stop();
       return;
     }
 
     // 第二层：自动切到下一首（仅 order/loop/random 模式）
-    state = state.copyWith(
-      errorMessage: l10n.playerPlayFailedTryingNext(failedSong),
-    );
+    state = state.copyWith(errorMessage: '"$failedSong" 播放失败，正在尝试下一首...');
     _skipToNextOnFailure();
   }
 
@@ -1589,10 +1471,7 @@ class PlayerNotifier extends Notifier<PlayerState> {
   Future<void> _skipToNextOnFailure() async {
     if (state.playlist.isEmpty || state.playlist.length <= 1) {
       // 只有一首歌或空列表，无法切歌
-      state = state.copyWith(
-        errorMessage: l10n.playerPlayFailedNoOthers,
-        isPlaying: false,
-      );
+      state = state.copyWith(errorMessage: '播放失败，无其他可播放的歌曲', isPlaying: false);
       _audioHandler.stop();
       return;
     }
@@ -1606,7 +1485,7 @@ class PlayerNotifier extends Notifier<PlayerState> {
         if (state.playMode == PlayMode.order) {
           // 顺序模式已到末尾，停止
           state = state.copyWith(
-            errorMessage: l10n.playerPlayFailedEndOfList,
+            errorMessage: '播放失败，已到播放列表末尾',
             isPlaying: false,
           );
           _audioHandler.stop();
@@ -1634,23 +1513,19 @@ class PlayerNotifier extends Notifier<PlayerState> {
     // 平台感知的转码目标：当前平台不能原生解码该格式时返回 'mp3'，否则 null。
     final targetFormat = AudioFormatHelper.getTranscodeFormat(nextSong.format);
     final isLocal = nextSong.type == 'local';
-    final prefs = await ref.read(appPreferencesProvider.future);
-    final quality = prefs.getAudioQuality();
-    final needsQualityTranscode =
-        quality != 'original' && quality.isNotEmpty;
 
-    // 本地歌曲且无需转码且无音质转码 → 无意义预热（本地文件随时可读）
-    if (isLocal && targetFormat == null && !needsQualityTranscode) return;
+    // 本地歌曲且无需转码 → 无意义预热（本地文件随时可读）
+    if (isLocal && targetFormat == null) return;
 
     // 取消之前的预加载
     _prefetchCancelToken?.cancel('new prefetch');
     _prefetchCancelToken = CancelToken();
 
     try {
+      // UrlHelper.buildSongUrl 会根据平台自动追加 format= 参数（需转码时）
       final songUrl = UrlHelper.buildSongUrl(
         nextSong.url!,
         songFormat: nextSong.format,
-        quality: quality,
       );
       final separator = songUrl.contains('?') ? '&' : '?';
       final prefetchUrl = '$songUrl${separator}prefetch=1';
@@ -1784,10 +1659,4 @@ final currentSongProvider = Provider<Song?>((ref) {
 final playerProgressProvider = Provider<double>((ref) {
   final state = ref.watch(playerStateProvider);
   return state.progress;
-});
-
-/// 便捷 Provider：当前播放队列的来源歌单 ID
-final sourcePlaylistIdProvider = Provider<int?>((ref) {
-  final state = ref.watch(playerStateProvider);
-  return state.sourcePlaylistId;
 });

--- a/lib/features/player/presentation/queue_page.dart
+++ b/lib/features/player/presentation/queue_page.dart
@@ -4,7 +4,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/utils/formatters.dart';
 import '../../../core/utils/url_helper.dart';
-import '../../../l10n/app_localizations.dart';
 import '../../../shared/models/song.dart';
 import '../../../shared/utils/responsive_snackbar.dart';
 import '../domain/player_state.dart';
@@ -114,7 +113,7 @@ class QueueBottomSheet extends ConsumerWidget {
             mainAxisSize: MainAxisSize.min,
             children: [
               Text(
-                AppLocalizations.of(context).playerQueueTitle,
+                '播放队列',
                 style: theme.textTheme.titleMedium?.copyWith(
                   fontWeight: FontWeight.bold,
                 ),
@@ -140,13 +139,13 @@ class QueueBottomSheet extends ConsumerWidget {
           if (state.playlist.isNotEmpty)
             IconButton(
               icon: const Icon(Icons.delete_outline_rounded),
-              tooltip: AppLocalizations.of(context).playerClearPlaylist,
+              tooltip: '清空播放列表',
               onPressed: () => _showClearConfirmation(context, notifier),
             ),
           // 关闭按钮
           IconButton(
             icon: const Icon(Icons.close_rounded),
-            tooltip: AppLocalizations.of(context).playerClose,
+            tooltip: '关闭',
             onPressed: () => Navigator.of(context).pop(),
           ),
         ],
@@ -171,14 +170,14 @@ class QueueBottomSheet extends ConsumerWidget {
           ),
           const SizedBox(height: 16),
           Text(
-            AppLocalizations.of(context).playerQueueEmpty,
+            '播放队列为空',
             style: theme.textTheme.titleMedium?.copyWith(
               color: colorScheme.onSurfaceVariant,
             ),
           ),
           const SizedBox(height: 8),
           Text(
-            AppLocalizations.of(context).playerQueueEmptyHint,
+            '添加歌曲到播放队列开始播放',
             style: theme.textTheme.bodyMedium?.copyWith(
               color: colorScheme.onSurfaceVariant.withValues(alpha: 0.7),
             ),
@@ -232,31 +231,30 @@ class QueueBottomSheet extends ConsumerWidget {
     notifier.removeFromPlaylist(index);
     ResponsiveSnackBar.show(
       context,
-      message: AppLocalizations.of(context).playerRemovedSong(song.title),
+      message: '已移除「${song.title}」',
       duration: const Duration(seconds: 2),
     );
   }
 
   /// 显示清空确认对话框
   void _showClearConfirmation(BuildContext context, PlayerNotifier notifier) {
-    final l10n = AppLocalizations.of(context);
     showDialog(
       context: context,
       builder:
           (dialogContext) => AlertDialog(
-            title: Text(l10n.playerClearQueueTitle),
-            content: Text(l10n.playerClearQueueConfirm),
+            title: const Text('清空播放队列'),
+            content: const Text('确定要清空播放队列吗？'),
             actions: [
               TextButton(
                 onPressed: () => Navigator.pop(dialogContext),
-                child: Text(l10n.commonCancel),
+                child: const Text('取消'),
               ),
               FilledButton(
                 onPressed: () {
                   notifier.clearPlaylist();
                   Navigator.pop(dialogContext); // 关闭确认对话框，队列弹窗由 ref.listen 自动关闭
                 },
-                child: Text(l10n.playerClear),
+                child: const Text('清空'),
               ),
             ],
           ),
@@ -335,18 +333,16 @@ class _QueueSongItem extends StatelessWidget {
                   clipBehavior: Clip.antiAlias,
                   child: Stack(
                     children: [
-                      if (coverUrl != null)
-                        ExcludeSemantics(
-                          child: CachedNetworkImage(
-                            imageUrl: UrlHelper.buildCoverUrl(coverUrl),
-                            fit: BoxFit.cover,
-                            width: 48,
-                            height: 48,
-                            placeholder:
-                                (_, _) => _buildCoverPlaceholder(colorScheme),
-                            errorWidget:
-                                (_, _, _) => _buildCoverPlaceholder(colorScheme),
-                          ),
+                      if (coverUrl != null && coverUrl.isNotEmpty)
+                        CachedNetworkImage(
+                          imageUrl: UrlHelper.buildCoverUrl(coverUrl),
+                          fit: BoxFit.cover,
+                          width: 48,
+                          height: 48,
+                          placeholder:
+                              (_, _) => _buildCoverPlaceholder(colorScheme),
+                          errorWidget:
+                              (_, _, _) => _buildCoverPlaceholder(colorScheme),
                         )
                       else
                         _buildCoverPlaceholder(colorScheme),
@@ -389,8 +385,7 @@ class _QueueSongItem extends StatelessWidget {
                       ),
                       const SizedBox(height: 4),
                       Text(
-                        song.artist ??
-                            AppLocalizations.of(context).playerUnknownArtist,
+                        song.artist ?? '未知艺术家',
                         style: textTheme.bodySmall?.copyWith(
                           color: colorScheme.onSurfaceVariant,
                         ),
@@ -415,7 +410,6 @@ class _QueueSongItem extends StatelessWidget {
                   onPressed: onRemove,
                   icon: const Icon(Icons.close_rounded),
                   iconSize: 20,
-                  tooltip: AppLocalizations.of(context).playerRemoveFromQueue,
                   style: IconButton.styleFrom(
                     foregroundColor: colorScheme.onSurfaceVariant,
                   ),

--- a/lib/features/player/presentation/widgets/desktop_full_player.dart
+++ b/lib/features/player/presentation/widgets/desktop_full_player.dart
@@ -7,7 +7,6 @@ import '../../../../core/theme/app_dimensions.dart';
 import '../../../../core/theme/responsive.dart';
 import '../../../../core/utils/color_extraction.dart';
 import '../../../../core/utils/url_helper.dart';
-import '../../../../l10n/app_localizations.dart';
 import '../../../../shared/widgets/favorite_button.dart';
 import '../../domain/player_state.dart';
 import '../providers/player_provider.dart';
@@ -16,9 +15,6 @@ import 'lyrics_view.dart';
 import 'play_controls.dart';
 import 'popup_controls.dart';
 import 'progress_bar.dart';
-import '../utils/player_song_actions.dart';
-import 'vinyl_ring.dart';
-import '../../../dlna/presentation/widgets/cast_button.dart';
 import 'volume_control.dart';
 
 /// Desktop/Tablet 全屏播放器（左右分栏布局）
@@ -55,21 +51,25 @@ class DesktopFullPlayer extends ConsumerStatefulWidget {
 
 class _DesktopFullPlayerState extends ConsumerState<DesktopFullPlayer>
     with SingleTickerProviderStateMixin {
-  /// 唱片环旋转动画控制器
-  late final AnimationController _rotationController;
+  /// 封面脉冲动画控制器
+  late final AnimationController _pulseController;
+  late final Animation<double> _pulseAnimation;
 
   @override
   void initState() {
     super.initState();
-    _rotationController = AnimationController(
+    _pulseController = AnimationController(
       vsync: this,
-      duration: const Duration(seconds: 28),
+      duration: const Duration(seconds: 2),
+    );
+    _pulseAnimation = Tween<double>(begin: 1.0, end: 1.02).animate(
+      CurvedAnimation(parent: _pulseController, curve: Curves.easeInOut),
     );
   }
 
   @override
   void dispose() {
-    _rotationController.dispose();
+    _pulseController.dispose();
     super.dispose();
   }
 
@@ -90,19 +90,22 @@ class _DesktopFullPlayerState extends ConsumerState<DesktopFullPlayer>
           Navigator.of(context).pop();
         }
       }
-      // 控制唱片环旋转动画
-      if (next.isPlaying && !_rotationController.isAnimating) {
-        _rotationController.repeat();
-      } else if (!next.isPlaying && _rotationController.isAnimating) {
-        _rotationController.stop();
+      // 控制封面脉冲动画
+      if (next.isPlaying && !_pulseController.isAnimating) {
+        _pulseController.repeat(reverse: true);
+      } else if (!next.isPlaying && _pulseController.isAnimating) {
+        _pulseController.animateTo(
+          0.0,
+          duration: const Duration(milliseconds: 300),
+        );
       }
     });
 
     // 初始播放状态动画
-    if (state.isPlaying && !_rotationController.isAnimating) {
+    if (state.isPlaying && !_pulseController.isAnimating) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (mounted && state.isPlaying && !_rotationController.isAnimating) {
-          _rotationController.repeat();
+        if (mounted && state.isPlaying && !_pulseController.isAnimating) {
+          _pulseController.repeat(reverse: true);
         }
       });
     }
@@ -126,19 +129,17 @@ class _DesktopFullPlayerState extends ConsumerState<DesktopFullPlayer>
       body: Stack(
         children: [
           // 背景模糊封面 / 无封面时的动态渐变
-          if (coverUrl != null)
+          if (coverUrl != null && coverUrl.isNotEmpty)
             Positioned.fill(
-              child: ExcludeSemantics(
-                child: ImageFiltered(
-                  imageFilter: ImageFilter.blur(sigmaX: 70, sigmaY: 70),
-                  child: Image.network(
-                    UrlHelper.buildCoverUrl(coverUrl),
-                    fit: BoxFit.cover,
-                    errorBuilder:
-                        (_, _, _) => Container(
-                          color: theme.colorScheme.surfaceContainerHighest,
-                        ),
-                  ),
+              child: ImageFiltered(
+                imageFilter: ImageFilter.blur(sigmaX: 50, sigmaY: 50),
+                child: Image.network(
+                  UrlHelper.buildCoverUrl(coverUrl),
+                  fit: BoxFit.cover,
+                  errorBuilder:
+                      (_, _, _) => Container(
+                        color: theme.colorScheme.surfaceContainerHighest,
+                      ),
                 ),
               ),
             )
@@ -155,25 +156,6 @@ class _DesktopFullPlayerState extends ConsumerState<DesktopFullPlayer>
                       palette.dominantColor.withValues(alpha: 0.6),
                       palette.darkMutedColor ?? palette.dominantColor,
                     ],
-                  ),
-                ),
-              ),
-            ),
-          // 径向环境光晕
-          if (palette != null)
-            Positioned.fill(
-              child: IgnorePointer(
-                child: DecoratedBox(
-                  decoration: BoxDecoration(
-                    gradient: RadialGradient(
-                      center: const Alignment(-0.6, -0.5),
-                      radius: 1.2,
-                      colors: [
-                        (palette.vibrantColor ?? palette.dominantColor)
-                            .withValues(alpha: 0.22),
-                        Colors.transparent,
-                      ],
-                    ),
                   ),
                 ),
               ),
@@ -237,9 +219,9 @@ class _DesktopFullPlayerState extends ConsumerState<DesktopFullPlayer>
                             child: Column(
                               mainAxisAlignment: MainAxisAlignment.center,
                               children: [
-                                // 封面带唱片环旋转
-                                VinylRing(
-                                  rotationAnimation: _rotationController,
+                                // 封面带脉冲动画
+                                ScaleTransition(
+                                  scale: _pulseAnimation,
                                   child: _buildCover(
                                     context,
                                     coverUrl,
@@ -265,10 +247,7 @@ class _DesktopFullPlayerState extends ConsumerState<DesktopFullPlayer>
                                 const SizedBox(height: 8),
                                 // 艺术家名
                                 Text(
-                                  song.artist ??
-                                      AppLocalizations.of(
-                                        context,
-                                      ).playerUnknownArtist,
+                                  song.artist ?? '未知艺术家',
                                   style: theme.textTheme.bodyLarge?.copyWith(
                                     color: theme.colorScheme.onSurfaceVariant,
                                   ),
@@ -312,7 +291,6 @@ class _DesktopFullPlayerState extends ConsumerState<DesktopFullPlayer>
                     onPrev: notifier.playPrev,
                     onNext: notifier.playNext,
                     size: 52,
-                    showGlow: true,
                   ),
                   const SizedBox(height: 12),
                   // 底部工具栏
@@ -343,45 +321,17 @@ class _DesktopFullPlayerState extends ConsumerState<DesktopFullPlayer>
           icon: const Icon(Icons.keyboard_arrow_down_rounded),
           iconSize: 32,
           color: topBarColor,
-          tooltip: AppLocalizations.of(context).playerCollapse,
         ),
         // 中间标题
         Text(
-          AppLocalizations.of(context).playerNowPlaying,
+          '正在播放',
           style: TextStyle(
             color: topBarColor.withValues(alpha: 0.9),
             fontSize: 14,
           ),
         ),
-        // 更多操作
-        PopupMenuButton<String>(
-          icon: const Icon(Icons.more_horiz_rounded, color: Colors.white),
-          onSelected: (value) {
-            if (value == 'delete') {
-              deleteCurrentSongFromPlayer(context, ref);
-            }
-          },
-          itemBuilder: (context) {
-            final colorScheme = Theme.of(context).colorScheme;
-            return [
-              PopupMenuItem(
-                value: 'delete',
-                child: ListTile(
-                  leading: Icon(
-                    Icons.delete_outline,
-                    color: colorScheme.error,
-                  ),
-                  title: Text(
-                    AppLocalizations.of(context).playerDeleteCurrentSong,
-                    style: TextStyle(color: colorScheme.error),
-                  ),
-                  dense: true,
-                  contentPadding: EdgeInsets.zero,
-                ),
-              ),
-            ];
-          },
-        ),
+        // 占位，保持布局对称
+        const SizedBox(width: 48),
       ],
     );
   }
@@ -394,27 +344,30 @@ class _DesktopFullPlayerState extends ConsumerState<DesktopFullPlayer>
     CoverPalette? palette,
   }) {
     final theme = Theme.of(context);
-    final glowColor = palette?.vibrantColor ?? palette?.dominantColor;
 
     return Container(
       width: size,
       height: size,
       decoration: BoxDecoration(
-        borderRadius: AppRadius.xlAll,
+        borderRadius: AppRadius.lgAll,
         color: theme.colorScheme.surfaceContainerHighest,
-        boxShadow: glowColor != null
-            ? AppEffects.primaryGlow(glowColor)
-            : AppEffects.softGlow(theme.colorScheme.onSurface),
+        boxShadow: [
+          BoxShadow(
+            color: (palette?.dominantColor ?? Colors.black).withValues(
+              alpha: 0.2,
+            ),
+            blurRadius: 20,
+            offset: const Offset(0, 10),
+          ),
+        ],
       ),
       clipBehavior: Clip.antiAlias,
       child:
-          coverUrl != null
-              ? ExcludeSemantics(
-                child: Image.network(
-                  UrlHelper.buildCoverUrl(coverUrl),
-                  fit: BoxFit.cover,
-                  errorBuilder: (_, _, _) => _buildPlaceholder(theme, size),
-                ),
+          coverUrl != null && coverUrl.isNotEmpty
+              ? Image.network(
+                UrlHelper.buildCoverUrl(coverUrl),
+                fit: BoxFit.cover,
+                errorBuilder: (_, _, _) => _buildPlaceholder(theme, size),
               )
               : _buildPlaceholder(theme, size),
     );
@@ -454,12 +407,6 @@ class _DesktopFullPlayerState extends ConsumerState<DesktopFullPlayer>
             onPlayModeChanged: notifier.setPlayMode,
           ),
         ),
-        // 投屏
-        const SizedBox(
-          width: 48,
-          height: 48,
-          child: CastButton(iconSize: 24),
-        ),
         // 音量
         SizedBox(
           width: 48,
@@ -490,7 +437,7 @@ class _DesktopFullPlayerState extends ConsumerState<DesktopFullPlayer>
               QueueBottomSheet.show(context);
             },
             icon: const Icon(Icons.queue_music_rounded),
-            tooltip: AppLocalizations.of(context).playerQueueTitle,
+            tooltip: '播放队列',
           ),
         ),
       ],

--- a/lib/features/player/presentation/widgets/desktop_player.dart
+++ b/lib/features/player/presentation/widgets/desktop_player.dart
@@ -3,17 +3,14 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../core/utils/formatters.dart';
 import '../../../../core/utils/url_helper.dart';
-import '../../../../l10n/app_localizations.dart';
 import '../../../../shared/widgets/favorite_button.dart';
 import '../../domain/player_state.dart';
 import '../providers/player_provider.dart';
 import 'desktop_full_player.dart';
 import 'play_controls.dart';
 import 'progress_bar.dart';
-import 'equalizer_panel.dart';
 import 'popup_controls.dart';
 import 'volume_control.dart';
-import '../../../dlna/presentation/widgets/cast_button.dart';
 
 /// 桌面端底部播放器栏
 class DesktopPlayer extends ConsumerWidget {
@@ -90,7 +87,7 @@ class DesktopPlayer extends ConsumerWidget {
           ),
           const SizedBox(width: 12),
           Text(
-            AppLocalizations.of(context).playerNoContent,
+            '无播放内容',
             style: theme.textTheme.bodyMedium?.copyWith(
               color: theme.colorScheme.onSurfaceVariant.withValues(alpha: 0.5),
             ),
@@ -106,71 +103,64 @@ class DesktopPlayer extends ConsumerWidget {
       children: [
         // 可点击区域（封面+标题）
         Expanded(
-          child: Semantics(
-            button: true,
-            label: AppLocalizations.of(context).playerOpenFullPlayer,
-            child: GestureDetector(
-              onTap: () => DesktopFullPlayer.show(context),
-              behavior: HitTestBehavior.opaque,
-              child: Row(
-                children: [
-                  // 封面
-                  Container(
-                    width: 56,
-                    height: 56,
-                    decoration: BoxDecoration(
-                      borderRadius: BorderRadius.circular(8),
-                      color: theme.colorScheme.surfaceContainerHighest,
-                    ),
-                    clipBehavior: Clip.antiAlias,
-                    child:
-                        coverUrl != null
-                            ? ExcludeSemantics(
-                              child: Image.network(
-                                UrlHelper.buildCoverUrl(coverUrl),
-                                fit: BoxFit.cover,
-                                errorBuilder:
-                                    (_, _, _) => Icon(
-                                      Icons.music_note_rounded,
-                                      color: theme.colorScheme.onSurfaceVariant,
-                                    ),
-                              ),
-                            )
-                            : Icon(
-                              Icons.music_note_rounded,
-                              color: theme.colorScheme.onSurfaceVariant,
-                            ),
+          child: GestureDetector(
+            onTap: () => DesktopFullPlayer.show(context),
+            behavior: HitTestBehavior.opaque,
+            child: Row(
+              children: [
+                // 封面
+                Container(
+                  width: 56,
+                  height: 56,
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(8),
+                    color: theme.colorScheme.surfaceContainerHighest,
                   ),
-                  const SizedBox(width: 12),
-                  // 标题和艺术家
-                  Expanded(
-                    child: Column(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          song.title,
-                          style: theme.textTheme.bodyMedium?.copyWith(
-                            fontWeight: FontWeight.w500,
-                          ),
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                        ),
-                        const SizedBox(height: 4),
-                        Text(
-                          song.artist ??
-                              AppLocalizations.of(context).playerUnknownArtist,
-                          style: theme.textTheme.bodySmall?.copyWith(
+                  clipBehavior: Clip.antiAlias,
+                  child:
+                      coverUrl != null && coverUrl.isNotEmpty
+                          ? Image.network(
+                            UrlHelper.buildCoverUrl(coverUrl),
+                            fit: BoxFit.cover,
+                            errorBuilder:
+                                (_, _, _) => Icon(
+                                  Icons.music_note_rounded,
+                                  color: theme.colorScheme.onSurfaceVariant,
+                                ),
+                          )
+                          : Icon(
+                            Icons.music_note_rounded,
                             color: theme.colorScheme.onSurfaceVariant,
                           ),
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
+                ),
+                const SizedBox(width: 12),
+                // 标题和艺术家
+                Expanded(
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        song.title,
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          fontWeight: FontWeight.w500,
                         ),
-                      ],
-                    ),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                      const SizedBox(height: 4),
+                      Text(
+                        song.artist ?? '未知艺术家',
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: theme.colorScheme.onSurfaceVariant,
+                        ),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ],
                   ),
-                ],
-              ),
+                ),
+              ],
             ),
           ),
         ),
@@ -239,70 +229,35 @@ class DesktopPlayer extends ConsumerWidget {
   ) {
     final theme = Theme.of(context);
 
-    final volume = ResponsiveVolumeControl(
-      volume: state.volume,
-      onVolumeChanged: notifier.setVolume,
-    );
-
-    // 音量之后的次要操作按钮
-    final actions = <Widget>[
-      // 均衡器
-      IconButton(
-        onPressed: () => showEqualizerSheet(context),
-        icon: const Icon(Icons.equalizer_rounded, size: 20),
-        tooltip: AppLocalizations.of(context).playerEqualizer,
-        visualDensity: VisualDensity.compact,
-      ),
-      // 投屏
-      const CastButton(iconSize: 20, visualDensity: VisualDensity.compact),
-      // 睡眠定时
-      _buildSleepTimerButton(context, state, notifier, theme),
-      // 歌词按钮
-      _buildLyricsButton(context, state, theme),
-      // 播放列表
-      IconButton(
-        onPressed: notifier.togglePlaylistDrawer,
-        icon: Icon(
-          Icons.queue_music_rounded,
-          size: 20,
-          color: state.showPlaylistDrawer ? theme.colorScheme.primary : null,
-        ),
-        tooltip: AppLocalizations.of(context).playerPlaylist,
-        visualDensity: VisualDensity.compact,
-      ),
-    ];
-
-    // 窗口较窄（如平板布局 / 缩小的桌面窗口）时，固定尺寸的按钮会超出
-    // Expanded(flex:3) 分配的宽度导致 RenderFlex 溢出。这里按可用宽度分档：
-    // - 空间充足：内联音量滑块 + 全部按钮（原布局）
-    // - 空间紧张：整体等比缩小并让音量退化为弹出图标，保证任意宽度都不溢出
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        if (constraints.maxWidth >= 300) {
-          return Row(
-            mainAxisAlignment: MainAxisAlignment.end,
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              _buildPlayModeButton(context, state, notifier, theme),
-              Flexible(child: volume),
-              ...actions,
-            ],
-          );
-        }
-        return FittedBox(
-          fit: BoxFit.scaleDown,
-          alignment: Alignment.centerRight,
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              _buildPlayModeButton(context, state, notifier, theme),
-              // 无界约束下 ResponsiveVolumeControl 自动退化为弹出图标
-              volume,
-              ...actions,
-            ],
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.end,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        // 播放模式
+        _buildPlayModeButton(context, state, notifier, theme),
+        // 音量控制：使用响应式组件自动适配
+        Flexible(
+          child: ResponsiveVolumeControl(
+            volume: state.volume,
+            onVolumeChanged: notifier.setVolume,
           ),
-        );
-      },
+        ),
+        // 睡眠定时
+        _buildSleepTimerButton(context, state, notifier, theme),
+        // 歌词按钮
+        _buildLyricsButton(context, state, theme),
+        // 播放列表
+        IconButton(
+          onPressed: notifier.togglePlaylistDrawer,
+          icon: Icon(
+            Icons.queue_music_rounded,
+            size: 20,
+            color: state.showPlaylistDrawer ? theme.colorScheme.primary : null,
+          ),
+          tooltip: '播放列表',
+          visualDensity: VisualDensity.compact,
+        ),
+      ],
     );
   }
 
@@ -354,7 +309,7 @@ class DesktopPlayer extends ConsumerWidget {
                 ? null
                 : theme.colorScheme.onSurfaceVariant.withValues(alpha: 0.5),
       ),
-      tooltip: AppLocalizations.of(context).playerLyrics,
+      tooltip: '歌词',
       visualDensity: VisualDensity.compact,
     );
   }

--- a/lib/features/player/presentation/widgets/mobile_player.dart
+++ b/lib/features/player/presentation/widgets/mobile_player.dart
@@ -1,13 +1,11 @@
 import 'dart:ui';
 
-import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../core/theme/app_dimensions.dart';
 import '../../../../core/utils/color_extraction.dart';
 import '../../../../core/utils/url_helper.dart';
-import '../../../../l10n/app_localizations.dart';
 import '../../../../shared/widgets/favorite_button.dart';
 import '../../domain/player_state.dart';
 import '../providers/player_provider.dart';
@@ -15,11 +13,7 @@ import '../queue_page.dart';
 import 'lyrics_view.dart';
 import 'play_controls.dart';
 import 'popup_controls.dart';
-import '../../../dlna/presentation/widgets/cast_button.dart';
 import 'progress_bar.dart';
-import 'equalizer_panel.dart';
-import '../utils/player_song_actions.dart';
-import 'vinyl_ring.dart';
 import 'volume_control.dart';
 
 /// 移动端全屏播放器
@@ -61,22 +55,26 @@ class _MobilePlayerState extends ConsumerState<MobilePlayer>
   /// 当前页面索引（0: 封面, 1: 歌词）
   int _currentPage = 0;
 
-  /// 唱片环旋转动画控制器
-  late final AnimationController _rotationController;
+  /// 封面脉冲动画控制器
+  late final AnimationController _pulseController;
+  late final Animation<double> _pulseAnimation;
 
   @override
   void initState() {
     super.initState();
-    _rotationController = AnimationController(
+    _pulseController = AnimationController(
       vsync: this,
-      duration: const Duration(seconds: 28),
+      duration: const Duration(seconds: 2),
+    );
+    _pulseAnimation = Tween<double>(begin: 1.0, end: 1.02).animate(
+      CurvedAnimation(parent: _pulseController, curve: Curves.easeInOut),
     );
   }
 
   @override
   void dispose() {
     _pageController.dispose();
-    _rotationController.dispose();
+    _pulseController.dispose();
     super.dispose();
   }
 
@@ -96,19 +94,22 @@ class _MobilePlayerState extends ConsumerState<MobilePlayer>
           Navigator.of(context).pop();
         }
       }
-      // 控制唱片环旋转动画
-      if (next.isPlaying && !_rotationController.isAnimating) {
-        _rotationController.repeat();
-      } else if (!next.isPlaying && _rotationController.isAnimating) {
-        _rotationController.stop();
+      // 控制封面脉冲动画
+      if (next.isPlaying && !_pulseController.isAnimating) {
+        _pulseController.repeat(reverse: true);
+      } else if (!next.isPlaying && _pulseController.isAnimating) {
+        _pulseController.animateTo(
+          0.0,
+          duration: const Duration(milliseconds: 300),
+        );
       }
     });
 
     // 初始播放状态动画（listen 只响应变化，初始状态需要手动处理）
-    if (state.isPlaying && !_rotationController.isAnimating) {
+    if (state.isPlaying && !_pulseController.isAnimating) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (mounted && state.isPlaying && !_rotationController.isAnimating) {
-          _rotationController.repeat();
+        if (mounted && state.isPlaying && !_pulseController.isAnimating) {
+          _pulseController.repeat(reverse: true);
         }
       });
     }
@@ -129,19 +130,17 @@ class _MobilePlayerState extends ConsumerState<MobilePlayer>
       body: Stack(
         children: [
           // 背景模糊封面 / 无封面时的动态渐变
-          if (coverUrl != null)
+          if (coverUrl != null && coverUrl.isNotEmpty)
             Positioned.fill(
-              child: ExcludeSemantics(
-                child: ImageFiltered(
-                  imageFilter: ImageFilter.blur(sigmaX: 70, sigmaY: 70),
-                  child: Image.network(
-                    UrlHelper.buildCoverUrl(coverUrl),
-                    fit: BoxFit.cover,
-                    errorBuilder:
-                        (_, _, _) => Container(
-                          color: theme.colorScheme.surfaceContainerHighest,
-                        ),
-                  ),
+              child: ImageFiltered(
+                imageFilter: ImageFilter.blur(sigmaX: 50, sigmaY: 50),
+                child: Image.network(
+                  UrlHelper.buildCoverUrl(coverUrl),
+                  fit: BoxFit.cover,
+                  errorBuilder:
+                      (_, _, _) => Container(
+                        color: theme.colorScheme.surfaceContainerHighest,
+                      ),
                 ),
               ),
             )
@@ -158,25 +157,6 @@ class _MobilePlayerState extends ConsumerState<MobilePlayer>
                       palette.dominantColor.withValues(alpha: 0.6),
                       palette.darkMutedColor ?? palette.dominantColor,
                     ],
-                  ),
-                ),
-              ),
-            ),
-          // 径向环境光晕
-          if (palette != null)
-            Positioned.fill(
-              child: IgnorePointer(
-                child: DecoratedBox(
-                  decoration: BoxDecoration(
-                    gradient: RadialGradient(
-                      center: const Alignment(-0.6, -0.5),
-                      radius: 1.2,
-                      colors: [
-                        (palette.vibrantColor ?? palette.dominantColor)
-                            .withValues(alpha: 0.22),
-                        Colors.transparent,
-                      ],
-                    ),
                   ),
                 ),
               ),
@@ -241,10 +221,10 @@ class _MobilePlayerState extends ConsumerState<MobilePlayer>
                             });
                           },
                           children: [
-                            // 页面1：封面（带唱片环旋转）
+                            // 页面1：封面（带脉冲动画）
                             Center(
-                              child: VinylRing(
-                                rotationAnimation: _rotationController,
+                              child: ScaleTransition(
+                                scale: _pulseAnimation,
                                 child: _buildCover(
                                   context,
                                   coverUrl,
@@ -288,8 +268,7 @@ class _MobilePlayerState extends ConsumerState<MobilePlayer>
                       ),
                       const SizedBox(height: 8),
                       Text(
-                        song.artist ??
-                            AppLocalizations.of(context).playerUnknownArtist,
+                        song.artist ?? '未知艺术家',
                         style: theme.textTheme.bodyLarge?.copyWith(
                           color: theme.colorScheme.onSurfaceVariant,
                         ),
@@ -313,11 +292,21 @@ class _MobilePlayerState extends ConsumerState<MobilePlayer>
                   ),
                 ),
                 const SizedBox(height: 16),
-                // 主控制行（播放模式 + 上一首/播放/下一首 + 收藏）
-                _buildControlsRow(context, state, notifier),
-                const SizedBox(height: 20),
-                // 工具行（投屏 + 音量 + 队列 + 更多）
-                _buildToolBar(context, state, notifier),
+                // 主控制按钮
+                PlayControls(
+                  isPlaying: state.isPlaying,
+                  hasPrev: state.hasPrev,
+                  hasNext: state.hasNext,
+                  isBuffering: state.isBuffering,
+                  onPlay: notifier.togglePlay,
+                  onPause: notifier.togglePlay,
+                  onPrev: notifier.playPrev,
+                  onNext: notifier.playNext,
+                  size: 64,
+                ),
+                const SizedBox(height: 24),
+                // 底部工具栏
+                _buildBottomBar(context, state, notifier),
                 const SizedBox(height: AppSpacing.md),
               ],
             ),
@@ -371,7 +360,6 @@ class _MobilePlayerState extends ConsumerState<MobilePlayer>
             icon: const Icon(Icons.keyboard_arrow_down_rounded),
             iconSize: 32,
             color: topBarColor,
-            tooltip: AppLocalizations.of(context).playerCollapse,
           ),
           // 歌曲信息（专辑名）
           if (song?.album != null && song!.album!.isNotEmpty)
@@ -389,79 +377,8 @@ class _MobilePlayerState extends ConsumerState<MobilePlayer>
             )
           else
             const Spacer(),
-          // 更多操作
-          PopupMenuButton<String>(
-            icon: Icon(
-              Icons.more_horiz_rounded,
-              color: state.sleepTimer != null
-                  ? Theme.of(context).colorScheme.primary
-                  : topBarColor,
-            ),
-            onSelected: (value) {
-              switch (value) {
-                case 'equalizer':
-                  showEqualizerSheet(context);
-                case 'sleep_timer':
-                  SleepTimerSheet.show(
-                    context,
-                    status: state.sleepTimer,
-                    isLive: state.currentSong?.isLive ?? false,
-                    onSetDuration: notifier.setSleepTimerByDuration,
-                    onSetAfterSongs: notifier.setSleepTimerAfterSongs,
-                    onCancel: notifier.cancelSleepTimer,
-                  );
-                case 'delete':
-                  deleteCurrentSongFromPlayer(context, ref);
-              }
-            },
-            itemBuilder: (context) {
-              final colorScheme = Theme.of(context).colorScheme;
-              final hasTimer = state.sleepTimer != null;
-              return [
-                PopupMenuItem(
-                  value: 'equalizer',
-                  child: ListTile(
-                    leading: const Icon(Icons.equalizer_rounded),
-                    title: Text(AppLocalizations.of(context).playerEqualizer),
-                    dense: true,
-                    contentPadding: EdgeInsets.zero,
-                  ),
-                ),
-                PopupMenuItem(
-                  value: 'sleep_timer',
-                  child: ListTile(
-                    leading: Icon(
-                      Icons.bedtime_outlined,
-                      color: hasTimer ? colorScheme.primary : null,
-                    ),
-                    title: Text(
-                      hasTimer
-                          ? AppLocalizations.of(context).playerSleepTimerOn
-                          : AppLocalizations.of(context).playerSleepTimer,
-                    ),
-                    dense: true,
-                    contentPadding: EdgeInsets.zero,
-                  ),
-                ),
-                const PopupMenuDivider(),
-                PopupMenuItem(
-                  value: 'delete',
-                  child: ListTile(
-                    leading: Icon(
-                      Icons.delete_outline,
-                      color: colorScheme.error,
-                    ),
-                    title: Text(
-                      AppLocalizations.of(context).playerDeleteCurrentSong,
-                      style: TextStyle(color: colorScheme.error),
-                    ),
-                    dense: true,
-                    contentPadding: EdgeInsets.zero,
-                  ),
-                ),
-              ];
-            },
-          ),
+          // 占位，保持布局对称
+          const SizedBox(width: 48),
         ],
       ),
     );
@@ -475,27 +392,29 @@ class _MobilePlayerState extends ConsumerState<MobilePlayer>
   }) {
     final theme = Theme.of(context);
 
-    final glowColor = palette?.vibrantColor ?? palette?.dominantColor;
-
     return Container(
       width: size,
       height: size,
       decoration: BoxDecoration(
-        borderRadius: AppRadius.xlAll,
+        borderRadius: AppRadius.lgAll,
         color: theme.colorScheme.surfaceContainerHighest,
-        boxShadow: glowColor != null
-            ? AppEffects.primaryGlow(glowColor)
-            : AppEffects.softGlow(theme.colorScheme.onSurface),
+        boxShadow: [
+          BoxShadow(
+            color: (palette?.dominantColor ?? Colors.black).withValues(
+              alpha: 0.2,
+            ),
+            blurRadius: 20,
+            offset: const Offset(0, 10),
+          ),
+        ],
       ),
       clipBehavior: Clip.antiAlias,
       child:
-          coverUrl != null
-              ? ExcludeSemantics(
-                child: Image.network(
-                  UrlHelper.buildCoverUrl(coverUrl),
-                  fit: BoxFit.cover,
-                  errorBuilder: (_, _, _) => _buildPlaceholder(theme, size),
-                ),
+          coverUrl != null && coverUrl.isNotEmpty
+              ? Image.network(
+                UrlHelper.buildCoverUrl(coverUrl),
+                fit: BoxFit.cover,
+                errorBuilder: (_, _, _) => _buildPlaceholder(theme, size),
               )
               : _buildPlaceholder(theme, size),
     );
@@ -509,8 +428,7 @@ class _MobilePlayerState extends ConsumerState<MobilePlayer>
     );
   }
 
-  /// Spotify 风格控制行：[播放模式] [上一首] [播放/暂停] [下一首] [收藏]
-  Widget _buildControlsRow(
+  Widget _buildBottomBar(
     BuildContext context,
     PlayerState state,
     PlayerNotifier notifier,
@@ -518,8 +436,16 @@ class _MobilePlayerState extends ConsumerState<MobilePlayer>
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: AppSpacing.lg),
       child: Row(
-        mainAxisAlignment: MainAxisAlignment.center,
+        mainAxisAlignment: MainAxisAlignment.spaceAround,
         children: [
+          // 收藏
+          SizedBox(
+            width: 48,
+            height: 48,
+            child: Center(
+              child: FavoriteButton(songId: state.currentSong!.id, songType: state.currentSong!.type, size: 24),
+            ),
+          ),
           // 播放模式
           SizedBox(
             width: 48,
@@ -529,60 +455,39 @@ class _MobilePlayerState extends ConsumerState<MobilePlayer>
               onPlayModeChanged: notifier.setPlayMode,
             ),
           ),
-          const SizedBox(width: 8),
-          // 主控制按钮
-          PlayControls(
-            isPlaying: state.isPlaying,
-            hasPrev: state.hasPrev,
-            hasNext: state.hasNext,
-            isBuffering: state.isBuffering,
-            onPlay: notifier.togglePlay,
-            onPause: notifier.togglePlay,
-            onPrev: notifier.playPrev,
-            onNext: notifier.playNext,
-            size: 76,
-            showGlow: true,
-            useRoundedRect: true,
-          ),
-          const SizedBox(width: 8),
-          // 收藏
+          // 音量
           SizedBox(
             width: 48,
             height: 48,
-            child: Center(
-              child: FavoriteButton(
-                songId: state.currentSong!.id,
-                songType: state.currentSong!.type,
-                size: 24,
-              ),
+            child: PopupVolumeControl(
+              volume: state.volume,
+              onVolumeChanged: notifier.setVolume,
             ),
           ),
-        ],
-      ),
-    );
-  }
-
-  /// Spotify 风格工具行：[投屏] [音量] [队列]（Web 无投屏时仅 [音量] [队列]）
-  Widget _buildToolBar(
-    BuildContext context,
-    PlayerState state,
-    PlayerNotifier notifier,
-  ) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xl),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-        children: [
-          if (!kIsWeb)
-            const CastButton(iconSize: 20),
-          PopupVolumeControl(
-            volume: state.volume,
-            onVolumeChanged: notifier.setVolume,
+          // 睡眠定时
+          SizedBox(
+            width: 48,
+            height: 48,
+            child: PopupSleepTimerControl(
+              status: state.sleepTimer,
+              isLive: state.currentSong?.isLive ?? false,
+              onSetDuration: notifier.setSleepTimerByDuration,
+              onSetAfterSongs: notifier.setSleepTimerAfterSongs,
+              onCancel: notifier.cancelSleepTimer,
+            ),
           ),
-          IconButton(
-            onPressed: () => QueueBottomSheet.show(context),
-            icon: const Icon(Icons.queue_music_rounded, size: 20),
-            tooltip: AppLocalizations.of(context).playerQueueTitle,
+          // 播放列表 - 显示播放队列浮层（直接覆盖在播放器之上）
+          SizedBox(
+            width: 48,
+            height: 48,
+            child: IconButton(
+              onPressed: () {
+                // 直接在播放器之上显示队列浮层，无需先关闭播放器
+                QueueBottomSheet.show(context);
+              },
+              icon: const Icon(Icons.queue_music_rounded),
+              tooltip: '播放队列',
+            ),
           ),
         ],
       ),

--- a/lib/features/player/presentation/widgets/playlist_drawer.dart
+++ b/lib/features/player/presentation/widgets/playlist_drawer.dart
@@ -4,7 +4,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../core/utils/formatters.dart';
 import '../../../../core/utils/url_helper.dart';
-import '../../../../l10n/app_localizations.dart';
 import '../../../../shared/models/song.dart';
 import '../../../../shared/utils/responsive_snackbar.dart';
 import '../providers/player_provider.dart';
@@ -60,7 +59,7 @@ class PlaylistDrawer extends ConsumerWidget {
         children: [
           // 标题和歌曲数量
           Text(
-            AppLocalizations.of(context).playerQueueTitle,
+            '播放队列',
             style: theme.textTheme.titleSmall?.copyWith(
               fontWeight: FontWeight.bold,
             ),
@@ -84,14 +83,14 @@ class PlaylistDrawer extends ConsumerWidget {
           if (state.playlist.isNotEmpty)
             IconButton(
               icon: const Icon(Icons.delete_outline_rounded, size: 18),
-              tooltip: AppLocalizations.of(context).playerClearPlaylist,
+              tooltip: '清空播放列表',
               visualDensity: VisualDensity.compact,
               onPressed: () => _showClearConfirmation(context, notifier),
             ),
           // 关闭按钮
           IconButton(
             icon: const Icon(Icons.close_rounded, size: 18),
-            tooltip: AppLocalizations.of(context).playerClose,
+            tooltip: '关闭',
             visualDensity: VisualDensity.compact,
             onPressed: notifier.closePlaylistDrawer,
           ),
@@ -117,14 +116,14 @@ class PlaylistDrawer extends ConsumerWidget {
           ),
           const SizedBox(height: 12),
           Text(
-            AppLocalizations.of(context).playerQueueEmpty,
+            '播放队列为空',
             style: theme.textTheme.bodyMedium?.copyWith(
               color: colorScheme.onSurfaceVariant,
             ),
           ),
           const SizedBox(height: 4),
           Text(
-            AppLocalizations.of(context).playerDrawerEmptyHint,
+            '添加歌曲开始播放',
             style: theme.textTheme.bodySmall?.copyWith(
               color: colorScheme.onSurfaceVariant.withValues(alpha: 0.7),
             ),
@@ -174,31 +173,30 @@ class PlaylistDrawer extends ConsumerWidget {
     notifier.removeFromPlaylist(index);
     ResponsiveSnackBar.show(
       context,
-      message: AppLocalizations.of(context).playerRemovedSong(song.title),
+      message: '已移除「${song.title}」',
       duration: const Duration(seconds: 2),
     );
   }
 
   /// 显示清空确认对话框
   void _showClearConfirmation(BuildContext context, PlayerNotifier notifier) {
-    final l10n = AppLocalizations.of(context);
     showDialog(
       context: context,
       builder:
           (dialogContext) => AlertDialog(
-            title: Text(l10n.playerClearQueueTitle),
-            content: Text(l10n.playerClearQueueConfirm),
+            title: const Text('清空播放队列'),
+            content: const Text('确定要清空播放队列吗？'),
             actions: [
               TextButton(
                 onPressed: () => Navigator.pop(dialogContext),
-                child: Text(l10n.commonCancel),
+                child: const Text('取消'),
               ),
               FilledButton(
                 onPressed: () {
                   notifier.clearPlaylist();
                   Navigator.pop(dialogContext);
                 },
-                child: Text(l10n.playerClear),
+                child: const Text('清空'),
               ),
             ],
           ),
@@ -281,18 +279,16 @@ class _DrawerSongItem extends StatelessWidget {
                   clipBehavior: Clip.antiAlias,
                   child: Stack(
                     children: [
-                      if (coverUrl != null)
-                        ExcludeSemantics(
-                          child: CachedNetworkImage(
-                            imageUrl: UrlHelper.buildCoverUrl(coverUrl),
-                            fit: BoxFit.cover,
-                            width: 36,
-                            height: 36,
-                            placeholder:
-                                (_, _) => _buildCoverPlaceholder(colorScheme),
-                            errorWidget:
-                                (_, _, _) => _buildCoverPlaceholder(colorScheme),
-                          ),
+                      if (coverUrl != null && coverUrl.isNotEmpty)
+                        CachedNetworkImage(
+                          imageUrl: UrlHelper.buildCoverUrl(coverUrl),
+                          fit: BoxFit.cover,
+                          width: 36,
+                          height: 36,
+                          placeholder:
+                              (_, _) => _buildCoverPlaceholder(colorScheme),
+                          errorWidget:
+                              (_, _, _) => _buildCoverPlaceholder(colorScheme),
                         )
                       else
                         _buildCoverPlaceholder(colorScheme),
@@ -335,8 +331,7 @@ class _DrawerSongItem extends StatelessWidget {
                       ),
                       const SizedBox(height: 2),
                       Text(
-                        song.artist ??
-                            AppLocalizations.of(context).playerUnknownArtist,
+                        song.artist ?? '未知艺术家',
                         style: textTheme.labelSmall?.copyWith(
                           color: colorScheme.onSurfaceVariant,
                         ),
@@ -361,7 +356,6 @@ class _DrawerSongItem extends StatelessWidget {
                   onPressed: onRemove,
                   icon: const Icon(Icons.close_rounded),
                   iconSize: 16,
-                  tooltip: AppLocalizations.of(context).playerRemoveFromPlaylist,
                   visualDensity: VisualDensity.compact,
                   style: IconButton.styleFrom(
                     foregroundColor: colorScheme.onSurfaceVariant,

--- a/lib/features/player/presentation/widgets/tv_player.dart
+++ b/lib/features/player/presentation/widgets/tv_player.dart
@@ -6,8 +6,6 @@ import '../../../../core/theme/tv_theme.dart';
 import '../../../../core/utils/color_extraction.dart';
 import '../../../../core/utils/formatters.dart';
 import '../../../../core/utils/url_helper.dart';
-import '../../../../l10n/app_localizations.dart';
-import '../../../../l10n/l10n_holder.dart';
 import '../../../../shared/widgets/tv_focusable.dart';
 import '../../domain/player_state.dart';
 import '../providers/player_provider.dart';
@@ -137,7 +135,7 @@ class _TvPlayerState extends ConsumerState<TvPlayer> {
           // 返回按钮（带标签）
           _TvPlayerControlButton(
             icon: Icons.arrow_back_rounded,
-            label: AppLocalizations.of(context).playerBack,
+            label: '返回',
             onPressed: () {
               notifier.closeFullPlayer();
               Navigator.of(context).maybePop();
@@ -148,7 +146,7 @@ class _TvPlayerState extends ConsumerState<TvPlayer> {
           const Spacer(),
           // 正在播放标题
           Text(
-            AppLocalizations.of(context).playerNowPlaying,
+            '正在播放',
             style: Theme.of(context).textTheme.titleLarge?.copyWith(
               fontSize: TvTheme.fontSizeBody,
               fontWeight: FontWeight.w500,
@@ -182,13 +180,11 @@ class _TvPlayerState extends ConsumerState<TvPlayer> {
       ),
       clipBehavior: Clip.antiAlias,
       child:
-          coverUrl != null
-              ? ExcludeSemantics(
-                child: Image.network(
-                  UrlHelper.buildCoverUrl(coverUrl),
-                  fit: BoxFit.cover,
-                  errorBuilder: (_, _, _) => _buildPlaceholderIcon(context),
-                ),
+          coverUrl != null && coverUrl.isNotEmpty
+              ? Image.network(
+                UrlHelper.buildCoverUrl(coverUrl),
+                fit: BoxFit.cover,
+                errorBuilder: (_, _, _) => _buildPlaceholderIcon(context),
               )
               : _buildPlaceholderIcon(context),
     );
@@ -211,7 +207,7 @@ class _TvPlayerState extends ConsumerState<TvPlayer> {
 
     if (!state.hasSong) {
       return Text(
-        AppLocalizations.of(context).playerNoContent,
+        '无播放内容',
         style: TvTheme.titleStyle(context).copyWith(
           color: theme.colorScheme.onSurfaceVariant.withValues(alpha: 0.5),
         ),
@@ -233,7 +229,7 @@ class _TvPlayerState extends ConsumerState<TvPlayer> {
         const SizedBox(height: TvTheme.spacingSmall),
         // 艺术家
         Text(
-          song.artist ?? AppLocalizations.of(context).playerUnknownArtist,
+          song.artist ?? '未知艺术家',
           style: TvTheme.captionStyle(context),
           textAlign: TextAlign.center,
           maxLines: 1,
@@ -282,7 +278,7 @@ class _TvPlayerState extends ConsumerState<TvPlayer> {
             builder:
                 (buttonContext) => _TvPlayerControlButton(
                   icon: _getPlayModeIcon(state.playMode),
-                  label: AppLocalizations.of(context).playerPlayMode,
+                  label: '播放模式',
                   onPressed:
                       () => _showPlayModeOverlay(
                         buttonContext,
@@ -302,7 +298,7 @@ class _TvPlayerState extends ConsumerState<TvPlayer> {
           // 音量减
           _TvPlayerControlButton(
             icon: Icons.volume_down_rounded,
-            label: AppLocalizations.of(context).playerVolumeDown,
+            label: '音量-',
             onPressed: () {
               final newVolume = (state.volume - 10).clamp(0.0, 100.0);
               notifier.setVolume(newVolume);
@@ -324,7 +320,7 @@ class _TvPlayerState extends ConsumerState<TvPlayer> {
           // 音量加
           _TvPlayerControlButton(
             icon: Icons.volume_up_rounded,
-            label: AppLocalizations.of(context).playerVolumeUp,
+            label: '音量+',
             onPressed: () {
               final newVolume = (state.volume + 10).clamp(0.0, 100.0);
               notifier.setVolume(newVolume);
@@ -336,7 +332,7 @@ class _TvPlayerState extends ConsumerState<TvPlayer> {
           // 上一首
           _TvPlayerControlButton(
             icon: Icons.skip_previous_rounded,
-            label: AppLocalizations.of(context).playerPrevious,
+            label: '上一首',
             onPressed: state.hasPrev ? notifier.playPrev : null,
             size: TvTheme.minButtonSize,
             iconSize: 40,
@@ -349,7 +345,7 @@ class _TvPlayerState extends ConsumerState<TvPlayer> {
           // 下一首
           _TvPlayerControlButton(
             icon: Icons.skip_next_rounded,
-            label: AppLocalizations.of(context).playerNext,
+            label: '下一首',
             onPressed: state.hasNext ? notifier.playNext : null,
             size: TvTheme.minButtonSize,
             iconSize: 40,
@@ -358,7 +354,7 @@ class _TvPlayerState extends ConsumerState<TvPlayer> {
           // 播放列表
           _TvPlayerControlButton(
             icon: Icons.queue_music_rounded,
-            label: AppLocalizations.of(context).playerPlaylist,
+            label: '播放列表',
             focusNode: _playlistButtonFocusNode,
             onPressed: () {
               final wasOpen = state.showPlaylistDrawer;
@@ -408,7 +404,7 @@ class _TvPlayerState extends ConsumerState<TvPlayer> {
           ),
           const SizedBox(height: 6),
           Text(
-            AppLocalizations.of(context).playerBuffering,
+            '缓冲中',
             style: TextStyle(
               fontSize: TvTheme.fontSizeCaption,
               color: Colors.white.withValues(alpha: 0.7),
@@ -442,15 +438,15 @@ class _TvPlayerState extends ConsumerState<TvPlayer> {
   String _getPlayModeTooltip(PlayMode mode) {
     switch (mode) {
       case PlayMode.order:
-        return l10n.playerModeOrder;
+        return '顺序播放';
       case PlayMode.loop:
-        return l10n.playerModeLoop;
+        return '列表循环';
       case PlayMode.single:
-        return l10n.playerModeSingle;
+        return '单曲循环';
       case PlayMode.random:
-        return l10n.playerModeRandom;
+        return '随机播放';
       case PlayMode.singlePlay:
-        return l10n.playerModeSinglePlay;
+        return '单曲播放';
     }
   }
 
@@ -652,9 +648,7 @@ class _TvPlayPauseButtonState extends State<_TvPlayPauseButton> {
           duration: TvTheme.focusAnimationDuration,
           curve: TvTheme.focusAnimationCurve,
           child: Text(
-            widget.isPlaying
-                ? AppLocalizations.of(context).playerPause
-                : AppLocalizations.of(context).playerPlay,
+            widget.isPlaying ? '暂停' : '播放',
             style: TextStyle(
               fontSize: TvTheme.fontSizeCaption,
               color: Colors.white.withValues(alpha: 0.7),
@@ -731,12 +725,9 @@ class _TvFocusableProgressBarState extends State<_TvFocusableProgressBar> {
           _isFocused = hasFocus;
         });
       },
-      child: Semantics(
-        slider: true,
-        label: AppLocalizations.of(context).playerProgress,
-        child: GestureDetector(
-          onTap: () => _focusNode.requestFocus(),
-          child: AnimatedContainer(
+      child: GestureDetector(
+        onTap: () => _focusNode.requestFocus(),
+        child: AnimatedContainer(
           duration: TvTheme.focusAnimationDuration,
           curve: TvTheme.focusAnimationCurve,
           padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
@@ -767,7 +758,7 @@ class _TvFocusableProgressBarState extends State<_TvFocusableProgressBar> {
                 child: Padding(
                   padding: const EdgeInsets.only(bottom: 4),
                   child: Text(
-                    AppLocalizations.of(context).playerSeekHint,
+                    '← → 快进/快退',
                     style: TextStyle(
                       fontSize: TvTheme.fontSizeCaption,
                       color: theme.colorScheme.primary.withValues(alpha: 0.8),
@@ -801,12 +792,6 @@ class _TvFocusableProgressBarState extends State<_TvFocusableProgressBar> {
                           (value * state.duration.inMilliseconds).round(),
                     );
                     widget.notifier.seek(newPosition);
-                  },
-                  semanticFormatterCallback: (value) {
-                    final pos = Duration(
-                      milliseconds: (value * state.duration.inMilliseconds).round(),
-                    );
-                    return '${Formatters.formatDuration(pos.inSeconds.toDouble())} / ${Formatters.formatDuration(state.duration.inSeconds.toDouble())}';
                   },
                 ),
               ),
@@ -843,7 +828,6 @@ class _TvFocusableProgressBarState extends State<_TvFocusableProgressBar> {
             ],
           ),
         ),
-      ),
       ),
     );
   }
@@ -904,13 +888,10 @@ class _TvPlayModeOverlayPanel extends StatelessWidget {
       children: [
         // 透明背景层，点击关闭
         Positioned.fill(
-          child: Semantics(
-            label: AppLocalizations.of(context).playerClose,
-            child: GestureDetector(
-              onTap: onDismiss,
-              behavior: HitTestBehavior.opaque,
-              child: Container(color: Colors.transparent),
-            ),
+          child: GestureDetector(
+            onTap: onDismiss,
+            behavior: HitTestBehavior.opaque,
+            child: Container(color: Colors.transparent),
           ),
         ),
         // 播放模式面板
@@ -1027,12 +1008,10 @@ class TvMiniPlayer extends ConsumerWidget {
                 ),
                 clipBehavior: Clip.antiAlias,
                 child:
-                    coverUrl != null
-                        ? ExcludeSemantics(
-                          child: Image.network(
-                            UrlHelper.buildCoverUrl(coverUrl),
-                            fit: BoxFit.cover,
-                          ),
+                    coverUrl != null && coverUrl.isNotEmpty
+                        ? Image.network(
+                          UrlHelper.buildCoverUrl(coverUrl),
+                          fit: BoxFit.cover,
                         )
                         : Icon(
                           Icons.music_note_rounded,
@@ -1056,7 +1035,7 @@ class TvMiniPlayer extends ConsumerWidget {
                     ),
                     const SizedBox(height: 4),
                     Text(
-                      song.artist ?? AppLocalizations.of(context).playerUnknownArtist,
+                      song.artist ?? '未知艺术家',
                       style: TvTheme.captionStyle(context),
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,

--- a/lib/features/playlist/presentation/playlist_detail_page.dart
+++ b/lib/features/playlist/presentation/playlist_detail_page.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 import 'dart:io' show File;
 
 import 'package:cached_network_image/cached_network_image.dart';
@@ -15,17 +14,14 @@ import '../../../core/utils/formatters.dart';
 import '../../../core/utils/url_helper.dart';
 import '../../../shared/models/song.dart';
 import '../../../shared/utils/responsive_snackbar.dart';
-import '../../../shared/widgets/delete_song_dialog.dart';
 import '../../../shared/widgets/empty_state.dart';
 import '../../../shared/widgets/song_picker_modal.dart';
-import '../../library/presentation/providers/songs_provider.dart';
-import '../../library/presentation/song_edit_page.dart';
 import '../../player/presentation/providers/player_provider.dart';
+import '../data/playlist_api.dart';
 import '../domain/playlist.dart';
 import 'providers/playlist_provider.dart';
 import 'widgets/song_cover_picker_modal.dart';
 import '../../../shared/widgets/loading_indicator.dart';
-import '../../../l10n/app_localizations.dart';
 
 /// 歌单详情页面
 class PlaylistDetailPage extends ConsumerStatefulWidget {
@@ -57,11 +53,6 @@ class _PlaylistDetailPageState extends ConsumerState<PlaylistDetailPage> {
   /// 排序模式下的可排序歌曲列表（本地副本）
   List<Song> _sortableSongs = [];
 
-  /// 搜索状态
-  bool _isSearchMode = false;
-  final _searchController = TextEditingController();
-  Timer? _debounceTimer;
-
   @override
   void initState() {
     super.initState();
@@ -72,27 +63,7 @@ class _PlaylistDetailPageState extends ConsumerState<PlaylistDetailPage> {
   void dispose() {
     _scrollController.removeListener(_onScroll);
     _scrollController.dispose();
-    _searchController.dispose();
-    _debounceTimer?.cancel();
     super.dispose();
-  }
-
-  void _onSearchChanged(String value) {
-    _debounceTimer?.cancel();
-    _debounceTimer = Timer(const Duration(milliseconds: 300), () {
-      ref.read(playlistSongsProvider(_playlistIdInt).notifier).search(value);
-    });
-  }
-
-  void _toggleSearch() {
-    setState(() {
-      _isSearchMode = !_isSearchMode;
-      if (!_isSearchMode) {
-        _searchController.clear();
-        _debounceTimer?.cancel();
-        ref.read(playlistSongsProvider(_playlistIdInt).notifier).search('');
-      }
-    });
   }
 
   /// 滚动监听：接近底部时触发分页加载
@@ -131,15 +102,10 @@ class _PlaylistDetailPageState extends ConsumerState<PlaylistDetailPage> {
     );
 
     if (mounted) {
-      final l10n = AppLocalizations.of(context);
       if (success) {
-        ref.read(playlistSongsProvider(_playlistIdInt).notifier).resetFilter();
-        ResponsiveSnackBar.showSuccess(context, message: l10n.playlistSortSaved);
+        ResponsiveSnackBar.showSuccess(context, message: '排序已保存');
       } else {
-        ResponsiveSnackBar.showError(
-          context,
-          message: l10n.playlistSortSaveFailed,
-        );
+        ResponsiveSnackBar.showError(context, message: '排序保存失败');
       }
     }
   }
@@ -167,10 +133,7 @@ class _PlaylistDetailPageState extends ConsumerState<PlaylistDetailPage> {
     final originalIds = fullSongs.map((s) => s.id).toList();
     if (_listEquals(songIds, originalIds)) {
       if (mounted) {
-        ResponsiveSnackBar.show(
-          context,
-          message: AppLocalizations.of(context).playlistAlreadySortedSongs,
-        );
+        ResponsiveSnackBar.show(context, message: '歌曲已是该排序顺序');
       }
       return;
     }
@@ -182,17 +145,13 @@ class _PlaylistDetailPageState extends ConsumerState<PlaylistDetailPage> {
     );
 
     if (mounted) {
-      final l10n = AppLocalizations.of(context);
       if (success) {
-        ref.read(playlistSongsProvider(_playlistIdInt).notifier).resetFilter();
         ResponsiveSnackBar.showSuccess(
           context,
-          message: ascending
-              ? l10n.playlistSortedByNameAsc
-              : l10n.playlistSortedByNameDesc,
+          message: ascending ? '已按名称升序排列' : '已按名称降序排列',
         );
       } else {
-        ResponsiveSnackBar.showError(context, message: l10n.playlistSortFailed);
+        ResponsiveSnackBar.showError(context, message: '排序失败');
       }
     }
   }
@@ -239,10 +198,7 @@ class _PlaylistDetailPageState extends ConsumerState<PlaylistDetailPage> {
     final originalIds = fullSongs.map((s) => s.id).toList();
     if (_listEquals(songIds, originalIds)) {
       if (mounted) {
-        ResponsiveSnackBar.show(
-          context,
-          message: AppLocalizations.of(context).playlistAlreadySortedSongs,
-        );
+        ResponsiveSnackBar.show(context, message: '歌曲已是该排序顺序');
       }
       return;
     }
@@ -254,15 +210,10 @@ class _PlaylistDetailPageState extends ConsumerState<PlaylistDetailPage> {
     );
 
     if (mounted) {
-      final l10n = AppLocalizations.of(context);
       if (success) {
-        ref.read(playlistSongsProvider(_playlistIdInt).notifier).resetFilter();
-        ResponsiveSnackBar.showSuccess(
-          context,
-          message: l10n.playlistSortedByNumber,
-        );
+        ResponsiveSnackBar.showSuccess(context, message: '已按数字前缀排序');
       } else {
-        ResponsiveSnackBar.showError(context, message: l10n.playlistSortFailed);
+        ResponsiveSnackBar.showError(context, message: '排序失败');
       }
     }
   }
@@ -329,24 +280,23 @@ class _PlaylistDetailPageState extends ConsumerState<PlaylistDetailPage> {
     if (_selectedSongIds.isEmpty) return;
 
     final count = _selectedSongIds.length;
-    final l10n = AppLocalizations.of(context);
     final confirmed = await showDialog<bool>(
       context: context,
       builder:
           (context) => AlertDialog(
-            title: Text(l10n.playlistBatchRemoveTitle),
-            content: Text(l10n.playlistBatchRemoveConfirm(count)),
+            title: const Text('批量移除'),
+            content: Text('确定要从歌单中移除 $count 首歌曲吗？'),
             actions: [
               TextButton(
                 onPressed: () => Navigator.of(context).pop(false),
-                child: Text(l10n.commonCancel),
+                child: const Text('取消'),
               ),
               FilledButton(
                 onPressed: () => Navigator.of(context).pop(true),
                 style: FilledButton.styleFrom(
                   backgroundColor: Theme.of(context).colorScheme.error,
                 ),
-                child: Text(l10n.playlistRemove),
+                child: const Text('移除'),
               ),
             ],
           ),
@@ -362,13 +312,10 @@ class _PlaylistDetailPageState extends ConsumerState<PlaylistDetailPage> {
 
     if (mounted) {
       if (success) {
-        ResponsiveSnackBar.showSuccess(
-          context,
-          message: l10n.playlistRemovedCount(count),
-        );
+        ResponsiveSnackBar.showSuccess(context, message: '已移除 $count 首歌曲');
         _exitSelectMode();
       } else {
-        ResponsiveSnackBar.showError(context, message: l10n.playlistRemoveFailed);
+        ResponsiveSnackBar.showError(context, message: '移除失败');
       }
     }
   }
@@ -409,21 +356,6 @@ class _PlaylistDetailPageState extends ConsumerState<PlaylistDetailPage> {
     Playlist playlist,
     AsyncValue<PaginatedSongsState> songsAsync,
   ) {
-    // 全站统一的双栏（主从）布局判断，见 context.useWideLayout
-    final useWideLayout = context.useWideLayout;
-    if (useWideLayout) {
-      return _buildWideContent(context, playlist, songsAsync);
-    }
-
-    return _buildNarrowContent(context, playlist, songsAsync);
-  }
-
-  /// 窄屏布局（Mobile / Tablet / Auto）：单列 CustomScrollView
-  Widget _buildNarrowContent(
-    BuildContext context,
-    Playlist playlist,
-    AsyncValue<PaginatedSongsState> songsAsync,
-  ) {
     final colorScheme = Theme.of(context).colorScheme;
 
     return CustomScrollView(
@@ -437,7 +369,7 @@ class _PlaylistDetailPageState extends ConsumerState<PlaylistDetailPage> {
           title: Text(playlist.name),
           leading: IconButton(
             icon: const Icon(Icons.arrow_back),
-            tooltip: AppLocalizations.of(context).playlistBack,
+            tooltip: '返回',
             onPressed: () {
               if (context.canPop()) {
                 context.pop();
@@ -469,10 +401,6 @@ class _PlaylistDetailPageState extends ConsumerState<PlaylistDetailPage> {
           child: _buildActionButtons(context, playlist, songsAsync),
         ),
 
-        // 搜索栏
-        if (_isSearchMode)
-          SliverToBoxAdapter(child: _buildSearchBar(context)),
-
         // 歌曲列表
         songsAsync.when(
           data: (state) => _buildSongList(context, playlist, state.items),
@@ -503,250 +431,11 @@ class _PlaylistDetailPageState extends ConsumerState<PlaylistDetailPage> {
     );
   }
 
-  /// 宽屏布局（Desktop / TV）：左右分栏
-  Widget _buildWideContent(
-    BuildContext context,
-    Playlist playlist,
-    AsyncValue<PaginatedSongsState> songsAsync,
-  ) {
-    final colorScheme = Theme.of(context).colorScheme;
-
-    return Column(
-      children: [
-        // 顶栏
-        AppBar(
-          backgroundColor: colorScheme.surface,
-          foregroundColor: colorScheme.onSurface,
-          title: Text(playlist.name),
-          leading: IconButton(
-            icon: const Icon(Icons.arrow_back),
-            tooltip: AppLocalizations.of(context).playlistBack,
-            onPressed: () {
-              if (context.canPop()) {
-                context.pop();
-              } else {
-                context.go('/playlists');
-              }
-            },
-          ),
-          actions: _buildAppBarActions(
-            context,
-            playlist,
-            songsAsync,
-            colorScheme,
-          ),
-        ),
-        // 左右分栏
-        Expanded(
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              // 左栏：封面 + 歌单信息 + 操作按钮
-              SizedBox(
-                width: 320,
-                child: _buildWideLeftPanel(context, playlist, songsAsync),
-              ),
-              VerticalDivider(
-                width: 1,
-                thickness: 1,
-                color: colorScheme.outlineVariant,
-              ),
-              // 右栏：歌曲列表
-              Expanded(
-                child: _buildWideRightPanel(context, playlist, songsAsync),
-              ),
-            ],
-          ),
-        ),
-      ],
-    );
-  }
-
-  /// 宽屏左栏：封面 + 歌单信息 + 操作按钮（固定不滚动或轻量滚动）
-  Widget _buildWideLeftPanel(
-    BuildContext context,
-    Playlist playlist,
-    AsyncValue<PaginatedSongsState> songsAsync,
-  ) {
-    final colorScheme = Theme.of(context).colorScheme;
-    final textTheme = Theme.of(context).textTheme;
-    final coverUrl = playlist.coverUrl;
-    final paletteAsync = ref.watch(coverColorsProvider(coverUrl));
-    final palette = paletteAsync.value;
-    final bgColor =
-        palette?.darkMutedColor ?? colorScheme.surfaceContainerHighest;
-
-    final songCount = songsAsync.value?.total ?? 0;
-    final songs = songsAsync.value?.items ?? [];
-
-    // 构建信息片段
-    final infoParts = <String>[];
-    final l10n = AppLocalizations.of(context);
-    if (playlist.type == 'radio') infoParts.add(l10n.songTypeRadio);
-    for (final label in playlist.labels) {
-      infoParts.add(_getLabelName(label));
-    }
-    infoParts.add(l10n.songsCount(songCount));
-    final subtitle = infoParts.join(' · ');
-
-    return SingleChildScrollView(
-      padding: const EdgeInsets.all(AppSpacing.lg),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.center,
-        children: [
-          // 封面
-          Container(
-            width: 240,
-            height: 240,
-            decoration: BoxDecoration(
-              borderRadius: AppRadius.xlAll,
-              boxShadow: AppShadows.medium,
-              gradient: LinearGradient(
-                begin: Alignment.topCenter,
-                end: Alignment.bottomCenter,
-                colors: [
-                  bgColor.withValues(alpha: 0.3),
-                  Colors.transparent,
-                ],
-              ),
-            ),
-            clipBehavior: Clip.antiAlias,
-            child: playlist.coverImageUrl != null
-                ? ExcludeSemantics(
-                    child: CachedNetworkImage(
-                      imageUrl: UrlHelper.buildCoverUrl(
-                        playlist.coverImageUrl!,
-                      ),
-                      fit: BoxFit.cover,
-                      placeholder: (context, url) => Container(
-                        color: colorScheme.surfaceContainerHighest,
-                      ),
-                      errorWidget: (context, url, error) =>
-                          _buildCoverPlaceholder(colorScheme, playlist),
-                    ),
-                  )
-                : _buildCoverPlaceholder(colorScheme, playlist),
-          ),
-          const SizedBox(height: AppSpacing.lg),
-          // 歌单名称
-          Text(
-            playlist.name,
-            style: textTheme.headlineSmall?.copyWith(
-              fontWeight: FontWeight.bold,
-            ),
-            textAlign: TextAlign.center,
-            maxLines: 2,
-            overflow: TextOverflow.ellipsis,
-          ),
-          // 描述
-          if (playlist.description?.isNotEmpty == true) ...[
-            const SizedBox(height: AppSpacing.sm),
-            Text(
-              playlist.description!,
-              style: textTheme.bodyMedium?.copyWith(
-                color: colorScheme.onSurfaceVariant,
-              ),
-              textAlign: TextAlign.center,
-              maxLines: 4,
-              overflow: TextOverflow.ellipsis,
-            ),
-          ],
-          const SizedBox(height: AppSpacing.sm),
-          // 标签 / 歌曲数
-          Text(
-            subtitle,
-            style: textTheme.bodySmall?.copyWith(
-              color: colorScheme.onSurfaceVariant,
-            ),
-            textAlign: TextAlign.center,
-          ),
-          const SizedBox(height: AppSpacing.lg),
-          // 操作按钮（纵向全宽排列）
-          if (!_isSortMode && !_isSelectMode) ...[
-            SizedBox(
-              width: double.infinity,
-              child: FilledButton.icon(
-                onPressed:
-                    songs.isEmpty ? null : () => _playAll(playlist, songs),
-                icon: const Icon(Icons.play_arrow),
-                label: Text(l10n.playlistPlayAll),
-                style: FilledButton.styleFrom(
-                  minimumSize: const Size(double.infinity, 48),
-                ),
-              ),
-            ),
-            const SizedBox(height: AppSpacing.sm),
-            SizedBox(
-              width: double.infinity,
-              child: OutlinedButton.icon(
-                onPressed: _addSongs,
-                icon: const Icon(Icons.add),
-                label: Text(l10n.playlistAddSongs),
-                style: OutlinedButton.styleFrom(
-                  minimumSize: const Size(double.infinity, 48),
-                ),
-              ),
-            ),
-          ],
-        ],
-      ),
-    );
-  }
-
-  /// 宽屏右栏：歌曲列表（含搜索栏、分页加载）
-  Widget _buildWideRightPanel(
-    BuildContext context,
-    Playlist playlist,
-    AsyncValue<PaginatedSongsState> songsAsync,
-  ) {
-    return Center(
-      child: ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: 1200),
-        child: CustomScrollView(
-          controller: _scrollController,
-          slivers: [
-            // 搜索栏
-            if (_isSearchMode)
-              SliverToBoxAdapter(child: _buildSearchBar(context)),
-
-            // 歌曲列表
-            songsAsync.when(
-              data: (state) => _buildSongList(context, playlist, state.items),
-              loading: () => SliverToBoxAdapter(
-                child: Column(
-                  children: [
-                    for (int i = 0; i < 5; i++) SkeletonLoader.listTile(),
-                  ],
-                ),
-              ),
-              error: (error, stack) =>
-                  SliverToBoxAdapter(child: _buildError(error.toString())),
-            ),
-
-            // 加载更多指示器
-            if (songsAsync.value != null)
-              SliverToBoxAdapter(
-                child: _buildSongsLoadMoreIndicator(songsAsync.value!),
-              ),
-
-            // 底部安全区域
-            SliverToBoxAdapter(
-              child: SizedBox(
-                height: MediaQuery.of(context).padding.bottom + 80,
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-
   /// 构建歌曲分页加载更多指示器
   Widget _buildSongsLoadMoreIndicator(PaginatedSongsState state) {
     // 排序模式 / 多选模式下不显示加载更多（避免影响交互）
     if (_isSortMode || _isSelectMode) return const SizedBox.shrink();
 
-    final l10n = AppLocalizations.of(context);
     if (state.loadMoreError != null) {
       return Padding(
         padding: const EdgeInsets.symmetric(vertical: 16),
@@ -758,7 +447,7 @@ class _PlaylistDetailPageState extends ConsumerState<PlaylistDetailPage> {
                         .read(playlistSongsProvider(_playlistIdInt).notifier)
                         .loadMore(),
             icon: const Icon(Icons.refresh),
-            label: Text(l10n.playlistLoadMoreRetry),
+            label: const Text('加载更多失败，点击重试'),
           ),
         ),
       );
@@ -774,7 +463,7 @@ class _PlaylistDetailPageState extends ConsumerState<PlaylistDetailPage> {
         padding: const EdgeInsets.symmetric(vertical: 16),
         child: Center(
           child: Text(
-            l10n.playlistAllLoaded(state.total),
+            '— 已全部加载（${state.total}） —',
             style: Theme.of(context).textTheme.bodySmall?.copyWith(
               color: Theme.of(context).colorScheme.onSurfaceVariant,
             ),
@@ -820,16 +509,14 @@ class _PlaylistDetailPageState extends ConsumerState<PlaylistDetailPage> {
             boxShadow: AppShadows.medium,
           ),
           clipBehavior: Clip.antiAlias,
-          child: playlist.coverImageUrl != null
-              ? ExcludeSemantics(
-                child: CachedNetworkImage(
-                    imageUrl: UrlHelper.buildCoverUrl(playlist.coverImageUrl!),
-                    fit: BoxFit.cover,
-                    placeholder: (context, url) =>
-                        Container(color: colorScheme.surfaceContainerHighest),
-                    errorWidget: (context, url, error) =>
-                        _buildCoverPlaceholder(colorScheme, playlist),
-                  ),
+          child: coverUrl != null && coverUrl.isNotEmpty
+              ? CachedNetworkImage(
+                  imageUrl: UrlHelper.buildCoverUrl(coverUrl),
+                  fit: BoxFit.cover,
+                  placeholder: (context, url) =>
+                      Container(color: colorScheme.surfaceContainerHighest),
+                  errorWidget: (context, url, error) =>
+                      _buildCoverPlaceholder(colorScheme, playlist),
                 )
               : _buildCoverPlaceholder(colorScheme, playlist),
         ),
@@ -861,12 +548,11 @@ class _PlaylistDetailPageState extends ConsumerState<PlaylistDetailPage> {
 
     // 构建信息片段
     final infoParts = <String>[];
-    final l10n = AppLocalizations.of(context);
-    if (playlist.type == 'radio') infoParts.add(l10n.songTypeRadio);
+    if (playlist.type == 'radio') infoParts.add('电台');
     for (final label in playlist.labels) {
       infoParts.add(_getLabelName(label));
     }
-    infoParts.add(l10n.songsCount(songCount));
+    infoParts.add('$songCount 首歌曲');
     final subtitle = infoParts.join(' · ');
 
     return Padding(
@@ -903,7 +589,6 @@ class _PlaylistDetailPageState extends ConsumerState<PlaylistDetailPage> {
     AsyncValue<PaginatedSongsState> songsAsync,
     ColorScheme colorScheme,
   ) {
-    final l10n = AppLocalizations.of(context);
     final songs = songsAsync.value?.items ?? [];
     final totalSongs = songsAsync.value?.total ?? songs.length;
     final isBuiltIn = playlist.isBuiltIn;
@@ -913,11 +598,11 @@ class _PlaylistDetailPageState extends ConsumerState<PlaylistDetailPage> {
       return [
         TextButton(
           onPressed: _cancelSortMode,
-          child: Text(l10n.commonCancel),
+          child: const Text('取消'),
         ),
         TextButton(
           onPressed: _exitSortMode,
-          child: Text(l10n.playlistDone),
+          child: const Text('完成'),
         ),
       ];
     }
@@ -936,104 +621,39 @@ class _PlaylistDetailPageState extends ConsumerState<PlaylistDetailPage> {
                 songs;
             _toggleSelectAll(fullSongs);
           },
-          child: Text(
-            _selectedSongIds.length == totalSongs
-                ? l10n.playlistDeselectAll
-                : l10n.selectAll,
-          ),
+          child: Text(_selectedSongIds.length == totalSongs ? '取消全选' : '全选'),
         ),
-        PopupMenuButton<String>(
-          enabled: _selectedSongIds.isNotEmpty,
-          onSelected: (value) {
-            if (value == 'remove') {
-              _batchRemoveSelectedSongs();
-            } else if (value == 'delete') {
-              _batchDeleteSelectedSongsFromLibrary();
-            }
-          },
-          itemBuilder: (context) => [
-            PopupMenuItem(
-              value: 'remove',
-              child: Text(l10n.playlistRemoveFromPlaylist),
-            ),
-            PopupMenuItem(
-              value: 'delete',
-              child: Text(
-                l10n.playlistDeleteFromLibrary,
-                style: TextStyle(color: colorScheme.error),
-              ),
-            ),
-          ],
-          child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 8),
-            child: Text(
-              l10n.playlistActionsCount(_selectedSongIds.length),
-              style: TextStyle(
-                color: _selectedSongIds.isEmpty
-                    ? colorScheme.onSurface.withValues(alpha: 0.38)
-                    : colorScheme.primary,
-              ),
-            ),
+        TextButton(
+          onPressed:
+              _selectedSongIds.isEmpty ? null : _batchRemoveSelectedSongs,
+          style: TextButton.styleFrom(
+            foregroundColor:
+                _selectedSongIds.isEmpty ? null : colorScheme.error,
           ),
+          child: Text('删除(${_selectedSongIds.length})'),
         ),
         TextButton(
           onPressed: _exitSelectMode,
-          child: Text(l10n.commonCancel),
+          child: const Text('取消'),
         ),
       ];
     }
 
-    final currentSort = songsAsync.value?.sort ?? 'position';
-    final hasKeyword = (songsAsync.value?.keyword ?? '').isNotEmpty;
-
     // 正常模式
     return [
-      IconButton(
-        icon: Icon(_isSearchMode ? Icons.search_off : Icons.search),
-        tooltip: l10n.playlistSearch,
-        onPressed: _toggleSearch,
-      ),
-      if (songs.isNotEmpty)
-        IconButton(
-          icon: const Icon(Icons.checklist),
-          tooltip: l10n.playlistMultiSelect,
-          onPressed: _enterSelectMode,
-        ),
       if (totalSongs > 1)
         PopupMenuButton<String>(
           icon: const Icon(Icons.sort),
-          tooltip: l10n.playlistSort,
+          tooltip: '排序',
           onSelected: (value) {
-            final notifier =
-                ref.read(playlistSongsProvider(_playlistIdInt).notifier);
             switch (value) {
-              // 视图排序（非破坏性）
-              case 'view_position':
-                notifier.setSort('position', 'asc');
-                break;
-              case 'view_added_at':
-                notifier.setSort('added_at', 'desc');
-                break;
-              case 'view_file_modified_at':
-                notifier.setSort('file_modified_at', 'desc');
-                break;
-              case 'view_title':
-                notifier.setSort('title', 'asc');
-                break;
-              case 'view_artist':
-                notifier.setSort('artist', 'asc');
-                break;
-              case 'view_duration':
-                notifier.setSort('duration', 'asc');
-                break;
-              // 永久排序
-              case 'perm_name_asc':
+              case 'name_asc':
                 _autoSortByName(songs, ascending: true);
                 break;
-              case 'perm_name_desc':
+              case 'name_desc':
                 _autoSortByName(songs, ascending: false);
                 break;
-              case 'perm_number':
+              case 'number_asc':
                 _autoSortByNumberPrefix(songs);
                 break;
               case 'manual':
@@ -1043,93 +663,61 @@ class _PlaylistDetailPageState extends ConsumerState<PlaylistDetailPage> {
           },
           itemBuilder:
               (context) => [
-                _buildSortMenuItem(
-                  value: 'view_position',
-                  icon: Icons.reorder,
-                  title: l10n.playlistSortCustom,
-                  isSelected: currentSort == 'position',
-                ),
-                _buildSortMenuItem(
-                  value: 'view_added_at',
-                  icon: Icons.schedule,
-                  title: l10n.playlistSortRecentlyAdded,
-                  isSelected: currentSort == 'added_at',
-                ),
-                _buildSortMenuItem(
-                  value: 'view_file_modified_at',
-                  icon: Icons.insert_drive_file_outlined,
-                  title: l10n.playlistSortFileTime,
-                  isSelected: currentSort == 'file_modified_at',
-                ),
-                _buildSortMenuItem(
-                  value: 'view_title',
-                  icon: Icons.sort_by_alpha,
-                  title: l10n.playlistSortTitle,
-                  isSelected: currentSort == 'title',
-                ),
-                _buildSortMenuItem(
-                  value: 'view_artist',
-                  icon: Icons.person,
-                  title: l10n.playlistSortArtist,
-                  isSelected: currentSort == 'artist',
-                ),
-                _buildSortMenuItem(
-                  value: 'view_duration',
-                  icon: Icons.timer,
-                  title: l10n.playlistSortDuration,
-                  isSelected: currentSort == 'duration',
-                ),
-                const PopupMenuDivider(),
-                if (!hasKeyword) ...[
-                  PopupMenuItem(
-                    value: 'perm_name_asc',
-                    child: ListTile(
-                      leading: const Icon(Icons.sort_by_alpha),
-                      title: Text(l10n.playlistSortNameAsc),
-                      dense: true,
-                      contentPadding: EdgeInsets.zero,
-                    ),
+                const PopupMenuItem(
+                  value: 'name_asc',
+                  child: ListTile(
+                    leading: Icon(Icons.sort_by_alpha),
+                    title: Text('按名称排序 A→Z'),
+                    dense: true,
+                    contentPadding: EdgeInsets.zero,
                   ),
-                  PopupMenuItem(
-                    value: 'perm_name_desc',
-                    child: ListTile(
-                      leading: const Icon(Icons.sort_by_alpha),
-                      title: Text(l10n.playlistSortNameDesc),
-                      dense: true,
-                      contentPadding: EdgeInsets.zero,
-                    ),
+                ),
+                const PopupMenuItem(
+                  value: 'name_desc',
+                  child: ListTile(
+                    leading: Icon(Icons.sort_by_alpha),
+                    title: Text('按名称排序 Z→A'),
+                    dense: true,
+                    contentPadding: EdgeInsets.zero,
                   ),
-                  PopupMenuItem(
-                    value: 'perm_number',
-                    child: ListTile(
-                      leading: const Icon(Icons.format_list_numbered),
-                      title: Text(l10n.playlistSortNumberPrefix),
-                      dense: true,
-                      contentPadding: EdgeInsets.zero,
-                    ),
+                ),
+                const PopupMenuItem(
+                  value: 'number_asc',
+                  child: ListTile(
+                    leading: Icon(Icons.format_list_numbered),
+                    title: Text('按数字前缀排序'),
+                    dense: true,
+                    contentPadding: EdgeInsets.zero,
                   ),
-                  if (currentSort == 'position')
-                    PopupMenuItem(
-                      value: 'manual',
-                      child: ListTile(
-                        leading: const Icon(Icons.drag_handle),
-                        title: Text(l10n.playlistSortManual),
-                        dense: true,
-                        contentPadding: EdgeInsets.zero,
-                      ),
-                    ),
-                ],
+                ),
+                const PopupMenuItem(
+                  value: 'manual',
+                  child: ListTile(
+                    leading: Icon(Icons.drag_handle),
+                    title: Text('手动排序'),
+                    dense: true,
+                    contentPadding: EdgeInsets.zero,
+                  ),
+                ),
               ],
         ),
+      if (songs.isNotEmpty)
+        IconButton(
+          icon: const Icon(Icons.checklist),
+          tooltip: '多选',
+          onPressed: _enterSelectMode,
+        ),
+      IconButton(
+        icon: const Icon(Icons.edit),
+        tooltip: isBuiltIn ? '修改封面' : '编辑歌单',
+        onPressed: () => _showEditDialog(playlist),
+      ),
       PopupMenuButton<String>(
         icon: const Icon(Icons.more_vert),
         onSelected: (value) {
           switch (value) {
             case 'add_songs':
               _addSongs();
-              break;
-            case 'edit':
-              _showEditDialog(playlist);
               break;
             case 'delete':
               _confirmDelete(playlist);
@@ -1138,103 +726,31 @@ class _PlaylistDetailPageState extends ConsumerState<PlaylistDetailPage> {
         },
         itemBuilder:
             (context) => [
-              PopupMenuItem(
+              const PopupMenuItem(
                 value: 'add_songs',
                 child: ListTile(
-                  leading: const Icon(Icons.add),
-                  title: Text(l10n.playlistAddSongs),
+                  leading: Icon(Icons.add),
+                  title: Text('添加歌曲'),
                   dense: true,
                   contentPadding: EdgeInsets.zero,
                 ),
               ),
-              PopupMenuItem(
-                value: 'edit',
-                child: ListTile(
-                  leading: const Icon(Icons.edit),
-                  title: Text(
-                    isBuiltIn ? l10n.playlistEditCover : l10n.playlistEditPlaylist,
-                  ),
-                  dense: true,
-                  contentPadding: EdgeInsets.zero,
-                ),
-              ),
-              if (!isBuiltIn) ...[
-                const PopupMenuDivider(),
+              if (!isBuiltIn)
                 PopupMenuItem(
                   value: 'delete',
                   child: ListTile(
                     leading: Icon(Icons.delete, color: colorScheme.error),
                     title: Text(
-                      l10n.playlistDelete,
+                      '删除歌单',
                       style: TextStyle(color: colorScheme.error),
                     ),
                     dense: true,
                     contentPadding: EdgeInsets.zero,
                   ),
                 ),
-              ],
             ],
       ),
     ];
-  }
-
-  Widget _buildSearchBar(BuildContext context) {
-    final colorScheme = Theme.of(context).colorScheme;
-    final l10n = AppLocalizations.of(context);
-    return Padding(
-      padding: const EdgeInsets.symmetric(
-        horizontal: AppSpacing.md,
-        vertical: AppSpacing.xs,
-      ),
-      child: TextField(
-        controller: _searchController,
-        autofocus: true,
-        decoration: InputDecoration(
-          prefixIcon: const Icon(Icons.search),
-          suffixIcon: _searchController.text.isNotEmpty
-              ? IconButton(
-                  icon: const Icon(Icons.clear),
-                  tooltip: l10n.clearSearch,
-                  onPressed: () {
-                    _searchController.clear();
-                    ref
-                        .read(
-                          playlistSongsProvider(_playlistIdInt).notifier,
-                        )
-                        .search('');
-                  },
-                )
-              : null,
-          hintText: l10n.playlistSearchHint,
-          filled: true,
-          fillColor: colorScheme.surfaceContainerHighest,
-          border: OutlineInputBorder(
-            borderRadius: BorderRadius.circular(AppRadius.md),
-            borderSide: BorderSide.none,
-          ),
-          contentPadding: const EdgeInsets.symmetric(vertical: 0),
-        ),
-        onChanged: _onSearchChanged,
-      ),
-    );
-  }
-
-  PopupMenuItem<String> _buildSortMenuItem({
-    required String value,
-    required IconData icon,
-    required String title,
-    required bool isSelected,
-  }) {
-    return PopupMenuItem(
-      value: value,
-      child: ListTile(
-        leading: Icon(icon),
-        title: Text(title),
-        trailing: isSelected ? const Icon(Icons.check, size: 18) : null,
-        dense: true,
-        contentPadding: EdgeInsets.zero,
-      ),
-    );
   }
 
   Widget _buildActionButtons(
@@ -1242,7 +758,6 @@ class _PlaylistDetailPageState extends ConsumerState<PlaylistDetailPage> {
     Playlist playlist,
     AsyncValue<PaginatedSongsState> songsAsync,
   ) {
-    final l10n = AppLocalizations.of(context);
     final songs = songsAsync.value?.items ?? [];
 
     // 排序模式和多选模式下隐藏操作按钮
@@ -1269,7 +784,7 @@ class _PlaylistDetailPageState extends ConsumerState<PlaylistDetailPage> {
                 onPressed:
                     songs.isEmpty ? null : () => _playAll(playlist, songs),
                 icon: const Icon(Icons.play_arrow),
-                label: Text(l10n.playlistPlayAll),
+                label: const Text('播放全部'),
                 style: FilledButton.styleFrom(
                   minimumSize: context.responsiveButtonMinSize,
                 ),
@@ -1282,7 +797,7 @@ class _PlaylistDetailPageState extends ConsumerState<PlaylistDetailPage> {
             OutlinedButton.icon(
               onPressed: _addSongs,
               icon: const Icon(Icons.add),
-              label: Text(l10n.playlistAddSongs),
+              label: const Text('添加歌曲'),
               style: OutlinedButton.styleFrom(
                 minimumSize: context.responsiveButtonMinSize,
               ),
@@ -1357,26 +872,19 @@ class _PlaylistDetailPageState extends ConsumerState<PlaylistDetailPage> {
           index: index + 1,
           onTap: () => _playSong(song, songs, index),
           onRemove: () => _removeSong(playlist.id, song),
-          onDeleteFromLibrary: () => _deleteSongFromLibrary(song),
-          onEdit: () => _navigateToEditSong(song),
-          onLongPress: () {
-            _enterSelectMode();
-            _toggleSongSelection(song.id);
-          },
         );
       }, childCount: songs.length),
     );
   }
 
   Widget _buildEmptySongs(BuildContext context, bool isBuiltIn) {
-    final l10n = AppLocalizations.of(context);
     return EmptyState(
       icon: Icons.music_off_outlined,
-      title: l10n.playlistEmptySongs,
-      subtitle: l10n.playlistEmptySongsSubtitle,
+      title: '歌单暂无歌曲',
+      subtitle: '添加一些喜欢的音乐吧',
       action: FilledButton.tonal(
         onPressed: _addSongs,
-        child: Text(l10n.playlistAddSongs),
+        child: const Text('添加歌曲'),
       ),
     );
   }
@@ -1384,7 +892,6 @@ class _PlaylistDetailPageState extends ConsumerState<PlaylistDetailPage> {
   Widget _buildError(String error) {
     final colorScheme = Theme.of(context).colorScheme;
     final textTheme = Theme.of(context).textTheme;
-    final l10n = AppLocalizations.of(context);
 
     return Center(
       child: Padding(
@@ -1394,7 +901,7 @@ class _PlaylistDetailPageState extends ConsumerState<PlaylistDetailPage> {
           children: [
             Icon(Icons.error_outline, size: 64, color: colorScheme.error),
             const SizedBox(height: 16),
-            Text(l10n.commonLoadFailed, style: textTheme.titleMedium),
+            Text('加载失败', style: textTheme.titleMedium),
             const SizedBox(height: 8),
             Text(
               error,
@@ -1410,7 +917,7 @@ class _PlaylistDetailPageState extends ConsumerState<PlaylistDetailPage> {
                 ref.invalidate(playlistSongsProvider(_playlistIdInt));
               },
               icon: const Icon(Icons.refresh),
-              label: Text(l10n.commonRetry),
+              label: const Text('重试'),
             ),
           ],
         ),
@@ -1419,12 +926,11 @@ class _PlaylistDetailPageState extends ConsumerState<PlaylistDetailPage> {
   }
 
   String _getLabelName(String label) {
-    final l10n = AppLocalizations.of(context);
     switch (label) {
       case 'built_in':
-        return l10n.playlistLabelBuiltIn;
+        return '内置';
       case 'auto_created':
-        return l10n.playlistLabelAutoCreated;
+        return '自动创建';
       default:
         return label;
     }
@@ -1442,10 +948,8 @@ class _PlaylistDetailPageState extends ConsumerState<PlaylistDetailPage> {
     );
 
     if (result == true && mounted) {
-      // 强制刷新歌单详情并等待完成，确保封面等变更立即生效
-      ref.invalidate(coverColorsProvider(playlist.coverUrl));
+      // 刷新歌单详情
       ref.invalidate(playlistDetailProvider(_playlistIdInt));
-      await ref.read(playlistDetailProvider(_playlistIdInt).future);
     }
   }
 
@@ -1482,37 +986,35 @@ class _PlaylistDetailPageState extends ConsumerState<PlaylistDetailPage> {
     );
 
     if (!mounted) return;
-    final l10n = AppLocalizations.of(context);
     if (result == null) {
-      ResponsiveSnackBar.showError(context, message: l10n.playlistAddSongsFailed);
+      ResponsiveSnackBar.showError(context, message: '添加歌曲失败');
       return;
     }
     final msg = result.skipped > 0
-        ? l10n.playlistAddedWithSkipped(result.added, result.skipped)
-        : l10n.playlistAddedCount(result.added);
+        ? '已添加 ${result.added} 首，跳过 ${result.skipped} 首（已存在或类型不兼容）'
+        : '已添加 ${result.added} 首歌曲';
     ResponsiveSnackBar.showSuccess(context, message: msg);
   }
 
   /// 确认删除歌单
   Future<void> _confirmDelete(Playlist playlist) async {
-    final l10n = AppLocalizations.of(context);
     final confirmed = await showDialog<bool>(
       context: context,
       builder:
           (context) => AlertDialog(
-            title: Text(l10n.playlistConfirmDelete),
-            content: Text(l10n.playlistDeleteConfirm(playlist.name)),
+            title: const Text('确认删除'),
+            content: Text('确定要删除歌单「${playlist.name}」吗？此操作不可恢复。'),
             actions: [
               TextButton(
                 onPressed: () => Navigator.of(context).pop(false),
-                child: Text(l10n.commonCancel),
+                child: const Text('取消'),
               ),
               FilledButton(
                 onPressed: () => Navigator.of(context).pop(true),
                 style: FilledButton.styleFrom(
                   backgroundColor: Theme.of(context).colorScheme.error,
                 ),
-                child: Text(l10n.commonDelete),
+                child: const Text('删除'),
               ),
             ],
           ),
@@ -1530,16 +1032,15 @@ class _PlaylistDetailPageState extends ConsumerState<PlaylistDetailPage> {
           // 没有返回栈时，跳转到歌单列表页
           context.go('/playlists');
         }
-        ResponsiveSnackBar.showSuccess(context, message: l10n.playlistDeleted);
+        ResponsiveSnackBar.showSuccess(context, message: '歌单已删除');
       }
     }
   }
 
   /// 播放全部（委托给 PlayerNotifier.playPlaylistById）
   Future<void> _playAll(Playlist playlist, List<Song> songs) async {
-    final l10n = AppLocalizations.of(context);
     if (songs.isEmpty) {
-      ResponsiveSnackBar.show(context, message: l10n.playlistEmpty);
+      ResponsiveSnackBar.show(context, message: '歌单为空');
       return;
     }
     final total = await ref
@@ -1547,14 +1048,11 @@ class _PlaylistDetailPageState extends ConsumerState<PlaylistDetailPage> {
         .playPlaylistById(playlist.id);
     if (!mounted) return;
     if (total < 0) {
-      ResponsiveSnackBar.showError(context, message: l10n.playlistPlayFailed);
+      ResponsiveSnackBar.showError(context, message: '播放失败');
     } else if (total == 0) {
-      ResponsiveSnackBar.show(context, message: l10n.playlistEmpty);
+      ResponsiveSnackBar.show(context, message: '歌单为空');
     } else {
-      ResponsiveSnackBar.show(
-        context,
-        message: l10n.playlistPlayingCount(total),
-      );
+      ResponsiveSnackBar.show(context, message: '播放全部 $total 首歌曲');
     }
   }
 
@@ -1563,30 +1061,26 @@ class _PlaylistDetailPageState extends ConsumerState<PlaylistDetailPage> {
     debugPrint('[Player] Play song: ${song.title} at index $index');
     ref
         .read(playerStateProvider.notifier)
-        .playPlaylist(songs, startIndex: index, sourcePlaylistId: _playlistIdInt);
-    ResponsiveSnackBar.show(
-      context,
-      message: AppLocalizations.of(context).playlistPlayingSong(song.title),
-    );
+        .playPlaylist(songs, startIndex: index);
+    ResponsiveSnackBar.show(context, message: '播放：${song.title}');
   }
 
   /// 从歌单移除歌曲
   Future<void> _removeSong(int playlistId, Song song) async {
-    final l10n = AppLocalizations.of(context);
     final confirmed = await showDialog<bool>(
       context: context,
       builder:
           (context) => AlertDialog(
-            title: Text(l10n.playlistRemoveSongTitle),
-            content: Text(l10n.playlistRemoveSongConfirm(song.title)),
+            title: const Text('移除歌曲'),
+            content: Text('确定要从歌单中移除「${song.title}」吗？'),
             actions: [
               TextButton(
                 onPressed: () => Navigator.of(context).pop(false),
-                child: Text(l10n.commonCancel),
+                child: const Text('取消'),
               ),
               FilledButton(
                 onPressed: () => Navigator.of(context).pop(true),
-                child: Text(l10n.playlistRemove),
+                child: const Text('移除'),
               ),
             ],
           ),
@@ -1600,96 +1094,7 @@ class _PlaylistDetailPageState extends ConsumerState<PlaylistDetailPage> {
       );
 
       if (success && mounted) {
-        ResponsiveSnackBar.showSuccess(
-          context,
-          message: l10n.playlistSongRemoved,
-        );
-      }
-    }
-  }
-
-  /// 编辑歌曲（跳转编辑页，返回后刷新歌单歌曲列表与歌曲库）
-  Future<void> _navigateToEditSong(Song song) async {
-    final result = await Navigator.push<bool>(
-      context,
-      MaterialPageRoute(
-        builder: (context) => SongEditPage(song: song, songType: song.type),
-      ),
-    );
-    if (result == true) {
-      ref.invalidate(playlistSongsProvider(_playlistIdInt));
-      ref.invalidate(songsListProvider);
-    }
-  }
-
-  Future<void> _deleteSongFromLibrary(Song song) async {
-    final l10n = AppLocalizations.of(context);
-    final result = await DeleteSongDialog.show(
-      context,
-      title: l10n.playlistDeleteSong,
-      content: l10n.playlistDeleteSongConfirm(song.title),
-    );
-    if (result == null || !mounted) return;
-
-    try {
-      await ref
-          .read(songsApiProvider)
-          .deleteSong(song.id, deleteFiles: result.deleteFiles);
-      ref.invalidate(playlistSongsProvider(_playlistIdInt));
-      ref.invalidate(songsListProvider);
-      _removeDeletedSongsFromPlayerQueue({song.id});
-      if (mounted) {
-        ResponsiveSnackBar.showSuccess(context, message: l10n.playlistSongDeleted);
-      }
-    } catch (e) {
-      if (mounted) {
-        ResponsiveSnackBar.showError(context, message: l10n.playlistDeleteFailed);
-      }
-    }
-  }
-
-  Future<void> _batchDeleteSelectedSongsFromLibrary() async {
-    if (_selectedSongIds.isEmpty) return;
-
-    final count = _selectedSongIds.length;
-    final ids = _selectedSongIds.toSet();
-    final l10n = AppLocalizations.of(context);
-    final result = await DeleteSongDialog.show(
-      context,
-      title: l10n.playlistBatchDelete,
-      content: l10n.playlistBatchDeleteSongsConfirm(count),
-    );
-    if (result == null || !mounted) return;
-
-    try {
-      final api = ref.read(songsApiProvider);
-      final deleted = await api.batchDeleteSongs(
-        ids.toList(),
-        deleteFiles: result.deleteFiles,
-      );
-      ref.invalidate(playlistSongsProvider(_playlistIdInt));
-      ref.invalidate(songsListProvider);
-      _removeDeletedSongsFromPlayerQueue(ids);
-      _exitSelectMode();
-      if (mounted) {
-        ResponsiveSnackBar.showSuccess(
-          context,
-          message: l10n.playlistDeletedSongsCount(deleted),
-        );
-      }
-    } catch (e) {
-      if (mounted) {
-        ResponsiveSnackBar.showError(context, message: l10n.playlistDeleteFailed);
-      }
-    }
-  }
-
-  void _removeDeletedSongsFromPlayerQueue(Set<int> deletedIds) {
-    final playerNotifier = ref.read(playerStateProvider.notifier);
-    final queue = ref.read(playerStateProvider).playlist;
-    for (int i = queue.length - 1; i >= 0; i--) {
-      if (deletedIds.contains(queue[i].id)) {
-        playerNotifier.removeFromPlaylist(i);
+        ResponsiveSnackBar.showSuccess(context, message: '歌曲已移除');
       }
     }
   }
@@ -1701,9 +1106,6 @@ class _SongListTile extends StatelessWidget {
   final int index;
   final VoidCallback onTap;
   final VoidCallback onRemove;
-  final VoidCallback? onDeleteFromLibrary;
-  final VoidCallback? onEdit;
-  final VoidCallback? onLongPress;
 
   /// 是否显示拖拽手柄（排序模式）
   final bool showDragHandle;
@@ -1726,9 +1128,6 @@ class _SongListTile extends StatelessWidget {
     required this.index,
     required this.onTap,
     required this.onRemove,
-    this.onDeleteFromLibrary,
-    this.onEdit,
-    this.onLongPress,
     this.showDragHandle = false,
     this.showCheckbox = false,
     this.isChecked = false,
@@ -1740,13 +1139,11 @@ class _SongListTile extends StatelessWidget {
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
     final textTheme = Theme.of(context).textTheme;
-    final l10n = AppLocalizations.of(context);
 
     final coverUrl = song.coverUrl;
 
     return ListTile(
       onTap: onTap,
-      onLongPress: onLongPress,
       leading: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
@@ -1785,18 +1182,16 @@ class _SongListTile extends StatelessWidget {
               width: 48,
               height: 48,
               child:
-                  coverUrl != null
-                      ? ExcludeSemantics(
-                        child: CachedNetworkImage(
-                          imageUrl: UrlHelper.buildCoverUrl(coverUrl),
-                          fit: BoxFit.cover,
-                          placeholder:
-                              (context, url) =>
-                                  _buildCoverPlaceholder(colorScheme),
-                          errorWidget:
-                              (context, url, error) =>
-                                  _buildCoverPlaceholder(colorScheme),
-                        ),
+                  coverUrl != null && coverUrl.isNotEmpty
+                      ? CachedNetworkImage(
+                        imageUrl: UrlHelper.buildCoverUrl(coverUrl),
+                        fit: BoxFit.cover,
+                        placeholder:
+                            (context, url) =>
+                                _buildCoverPlaceholder(colorScheme),
+                        errorWidget:
+                            (context, url, error) =>
+                                _buildCoverPlaceholder(colorScheme),
                       )
                       : _buildCoverPlaceholder(colorScheme),
             ),
@@ -1805,7 +1200,7 @@ class _SongListTile extends StatelessWidget {
       ),
       title: Text(song.title, maxLines: 1, overflow: TextOverflow.ellipsis),
       subtitle: Text(
-        song.artist ?? l10n.playlistUnknownArtist,
+        song.artist ?? '未知艺术家',
         maxLines: 1,
         overflow: TextOverflow.ellipsis,
         style: textTheme.bodySmall?.copyWith(
@@ -1831,44 +1226,21 @@ class _SongListTile extends StatelessWidget {
                       color: colorScheme.onSurfaceVariant,
                     ),
                     onSelected: (value) {
-                      if (value == 'edit') {
-                        onEdit?.call();
-                      } else if (value == 'remove') {
+                      if (value == 'remove') {
                         onRemove();
-                      } else if (value == 'delete') {
-                        onDeleteFromLibrary?.call();
                       }
                     },
                     itemBuilder:
                         (context) => [
-                          if (onEdit != null)
-                            PopupMenuItem(
-                              value: 'edit',
-                              child: ListTile(
-                                leading: const Icon(Icons.edit),
-                                title: Text(l10n.playlistEditAction),
-                                dense: true,
-                                contentPadding: EdgeInsets.zero,
-                              ),
-                            ),
                           PopupMenuItem(
                             value: 'remove',
                             child: ListTile(
-                              leading: const Icon(Icons.remove_circle_outline),
-                              title: Text(l10n.playlistRemoveFromPlaylist),
-                              dense: true,
-                              contentPadding: EdgeInsets.zero,
-                            ),
-                          ),
-                          PopupMenuItem(
-                            value: 'delete',
-                            child: ListTile(
                               leading: Icon(
-                                Icons.delete_outline,
+                                Icons.remove_circle_outline,
                                 color: colorScheme.error,
                               ),
                               title: Text(
-                                l10n.playlistDeleteFromLibrary,
+                                '从歌单移除',
                                 style: TextStyle(color: colorScheme.error),
                               ),
                               dense: true,
@@ -1921,9 +1293,9 @@ class _PlaylistEditDialogState extends ConsumerState<_PlaylistEditDialog> {
   /// 本地选择的文件
   PlatformFile? _localFile;
 
-  /// 从歌曲选择的封面信息
+  /// 从歌曲选择的封面路径
+  String? _selectedCoverPath;
   String? _selectedCoverUrl;
-  int? _selectedCoverSongId;
 
   /// 是否正在保存
   bool _isSaving = false;
@@ -1973,10 +1345,7 @@ class _PlaylistEditDialogState extends ConsumerState<_PlaylistEditDialog> {
       }
     } catch (e) {
       if (mounted) {
-        ResponsiveSnackBar.showError(
-          context,
-          message: AppLocalizations.of(context).playlistPickImageFailed('$e'),
-        );
+        ResponsiveSnackBar.showError(context, message: '选择图片失败: $e');
       }
     }
   }
@@ -1986,8 +1355,8 @@ class _PlaylistEditDialogState extends ConsumerState<_PlaylistEditDialog> {
     final result = await showSongCoverPicker(context, widget.playlistId);
     if (result != null) {
       setState(() {
-        _selectedCoverSongId = result['songId'] as int?;
-        _selectedCoverUrl = result['coverUrl'] as String?;
+        _selectedCoverPath = result['coverPath'];
+        _selectedCoverUrl = result['coverUrl'];
         _coverMode = 'song';
         _localFile = null;
       });
@@ -1999,17 +1368,16 @@ class _PlaylistEditDialogState extends ConsumerState<_PlaylistEditDialog> {
     setState(() {
       _coverMode = 'clear';
       _localFile = null;
+      _selectedCoverPath = null;
       _selectedCoverUrl = null;
-      _selectedCoverSongId = null;
     });
   }
 
   /// 保存
   Future<void> _save() async {
-    final l10n = AppLocalizations.of(context);
     final name = _nameController.text.trim();
     if (name.isEmpty) {
-      ResponsiveSnackBar.showError(context, message: l10n.playlistNameRequired);
+      ResponsiveSnackBar.showError(context, message: '请输入歌单名称');
       return;
     }
     setState(() => _isSaving = true);
@@ -2027,10 +1395,7 @@ class _PlaylistEditDialogState extends ConsumerState<_PlaylistEditDialog> {
         );
         if (uploadedPlaylist == null) {
           if (mounted) {
-            ResponsiveSnackBar.showError(
-              context,
-              message: l10n.playlistCoverUploadFailed,
-            );
+            ResponsiveSnackBar.showError(context, message: '封面上传失败');
           }
           return;
         }
@@ -2040,13 +1405,13 @@ class _PlaylistEditDialogState extends ConsumerState<_PlaylistEditDialog> {
           name: name,
           description: description.isEmpty ? null : description,
         );
-      } else if (_coverMode == 'song' && _selectedCoverSongId != null) {
+      } else if (_coverMode == 'song') {
         // 从歌曲选择的封面
         await notifier.updatePlaylist(
           widget.playlistId,
           name: name,
           description: description.isEmpty ? null : description,
-          coverSongId: _selectedCoverSongId,
+          coverPath: _selectedCoverPath ?? '',
         );
       } else if (_coverMode == 'clear') {
         // 清除封面
@@ -2069,10 +1434,7 @@ class _PlaylistEditDialogState extends ConsumerState<_PlaylistEditDialog> {
       }
     } catch (e) {
       if (mounted) {
-        ResponsiveSnackBar.showError(
-          context,
-          message: l10n.playlistSaveFailed('$e'),
-        );
+        ResponsiveSnackBar.showError(context, message: '保存失败: $e');
       }
     } finally {
       if (mounted) {
@@ -2084,18 +1446,13 @@ class _PlaylistEditDialogState extends ConsumerState<_PlaylistEditDialog> {
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
-    final l10n = AppLocalizations.of(context);
     final hasCover =
         _coverMode != 'clear' &&
         (_coverMode == 'local' ||
             _coverMode == 'song' ||
             widget.playlist.coverUrl?.isNotEmpty == true);
     return AlertDialog(
-      title: Text(
-        widget.playlist.isBuiltIn
-            ? l10n.playlistEditCover
-            : l10n.playlistEditPlaylist,
-      ),
+      title: Text(widget.playlist.isBuiltIn ? '修改封面' : '编辑歌单'),
       content: SingleChildScrollView(
         child: SizedBox(
           width: 320,
@@ -2123,12 +1480,12 @@ class _PlaylistEditDialogState extends ConsumerState<_PlaylistEditDialog> {
                   OutlinedButton.icon(
                     onPressed: _isSaving ? null : _pickLocalImage,
                     icon: const Icon(Icons.upload, size: 18),
-                    label: Text(l10n.playlistUploadImage),
+                    label: const Text('上传图片'),
                   ),
                   OutlinedButton.icon(
                     onPressed: _isSaving ? null : _pickFromSongs,
                     icon: const Icon(Icons.music_note, size: 18),
-                    label: Text(l10n.playlistPickFromSongs),
+                    label: const Text('从歌曲选择'),
                   ),
                   if (hasCover)
                     TextButton.icon(
@@ -2139,7 +1496,7 @@ class _PlaylistEditDialogState extends ConsumerState<_PlaylistEditDialog> {
                         color: colorScheme.error,
                       ),
                       label: Text(
-                        l10n.playlistClear,
+                        '清除',
                         style: TextStyle(color: colorScheme.error),
                       ),
                     ),
@@ -2149,9 +1506,9 @@ class _PlaylistEditDialogState extends ConsumerState<_PlaylistEditDialog> {
               // 歌单名称
               TextField(
                 controller: _nameController,
-                decoration: InputDecoration(
-                  labelText: l10n.playlistNameLabel,
-                  border: const OutlineInputBorder(),
+                decoration: const InputDecoration(
+                  labelText: '歌单名称',
+                  border: OutlineInputBorder(),
                 ),
                 enabled: !_isSaving && !widget.playlist.isBuiltIn,
               ),
@@ -2159,9 +1516,9 @@ class _PlaylistEditDialogState extends ConsumerState<_PlaylistEditDialog> {
               // 歌单描述
               TextField(
                 controller: _descController,
-                decoration: InputDecoration(
-                  labelText: l10n.playlistDescLabel,
-                  border: const OutlineInputBorder(),
+                decoration: const InputDecoration(
+                  labelText: '歌单描述',
+                  border: OutlineInputBorder(),
                 ),
                 maxLines: 3,
                 enabled: !_isSaving && !widget.playlist.isBuiltIn,
@@ -2173,7 +1530,7 @@ class _PlaylistEditDialogState extends ConsumerState<_PlaylistEditDialog> {
       actions: [
         TextButton(
           onPressed: _isSaving ? null : () => Navigator.of(context).pop(),
-          child: Text(l10n.commonCancel),
+          child: const Text('取消'),
         ),
         FilledButton(
           onPressed: _isSaving ? null : _save,
@@ -2184,7 +1541,7 @@ class _PlaylistEditDialogState extends ConsumerState<_PlaylistEditDialog> {
                     height: 16,
                     child: CircularProgressIndicator(strokeWidth: 2),
                   )
-                  : Text(l10n.playlistSave),
+                  : const Text('保存'),
         ),
       ],
     );
@@ -2202,16 +1559,14 @@ class _PlaylistEditDialogState extends ConsumerState<_PlaylistEditDialog> {
 
     // 网络图片预览
     final previewUrl = _previewCoverUrl;
-    if (previewUrl != null && previewUrl.isNotEmpty) {
-      return ExcludeSemantics(
-        child: CachedNetworkImage(
-          imageUrl: UrlHelper.buildCoverUrl(previewUrl),
-          fit: BoxFit.cover,
-          placeholder:
-              (context, url) =>
-                  const Center(child: CircularProgressIndicator(strokeWidth: 2)),
-          errorWidget: (context, url, error) => _buildPlaceholder(colorScheme),
-        ),
+    if (previewUrl != null) {
+      return CachedNetworkImage(
+        imageUrl: previewUrl,
+        fit: BoxFit.cover,
+        placeholder:
+            (context, url) =>
+                const Center(child: CircularProgressIndicator(strokeWidth: 2)),
+        errorWidget: (context, url, error) => _buildPlaceholder(colorScheme),
       );
     }
 

--- a/lib/features/playlist/presentation/playlists_page.dart
+++ b/lib/features/playlist/presentation/playlists_page.dart
@@ -8,7 +8,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../config/constants.dart';
-import '../../../core/theme/app_dimensions.dart';
 import '../../../core/theme/responsive.dart';
 import '../../../core/utils/url_helper.dart';
 import '../../../shared/utils/responsive_snackbar.dart';
@@ -19,7 +18,6 @@ import 'providers/playlist_view_provider.dart';
 import 'widgets/playlist_card.dart';
 import 'widgets/playlist_list_item.dart';
 import 'widgets/song_cover_picker_modal.dart';
-import '../../../l10n/app_localizations.dart';
 
 /// 歌单列表页面
 class PlaylistsPage extends ConsumerStatefulWidget {
@@ -37,9 +35,6 @@ class _PlaylistsPageState extends ConsumerState<PlaylistsPage> {
   /// 排序模式
   bool _isSortMode = false;
   List<Playlist> _sortablePlaylists = [];
-
-  /// 是否显示隐藏歌单
-  bool _showHidden = false;
 
   /// 触底加载预留距离（提前 300px 触发下一页加载）
   static const double _loadMoreThreshold = 300.0;
@@ -125,14 +120,10 @@ class _PlaylistsPageState extends ConsumerState<PlaylistsPage> {
     final success = await notifier.reorderPlaylists(playlistIds);
 
     if (mounted) {
-      final l10n = AppLocalizations.of(context);
       if (success) {
-        ResponsiveSnackBar.showSuccess(context, message: l10n.playlistSortSaved);
+        ResponsiveSnackBar.showSuccess(context, message: '排序已保存');
       } else {
-        ResponsiveSnackBar.showError(
-          context,
-          message: l10n.playlistSortSaveFailed,
-        );
+        ResponsiveSnackBar.showError(context, message: '排序保存失败');
       }
     }
   }
@@ -168,10 +159,7 @@ class _PlaylistsPageState extends ConsumerState<PlaylistsPage> {
     final originalIds = fullPlaylists.map((p) => p.id).toList();
     if (_listEquals(playlistIds, originalIds)) {
       if (mounted) {
-        ResponsiveSnackBar.show(
-          context,
-          message: AppLocalizations.of(context).playlistAlreadySortedPlaylists,
-        );
+        ResponsiveSnackBar.show(context, message: '歌单已是该排序顺序');
       }
       return;
     }
@@ -180,16 +168,13 @@ class _PlaylistsPageState extends ConsumerState<PlaylistsPage> {
     final success = await notifier.reorderPlaylists(playlistIds);
 
     if (mounted) {
-      final l10n = AppLocalizations.of(context);
       if (success) {
         ResponsiveSnackBar.showSuccess(
           context,
-          message: ascending
-              ? l10n.playlistSortedByNameAsc
-              : l10n.playlistSortedByNameDesc,
+          message: ascending ? '已按名称升序排列' : '已按名称降序排列',
         );
       } else {
-        ResponsiveSnackBar.showError(context, message: l10n.playlistSortFailed);
+        ResponsiveSnackBar.showError(context, message: '排序失败');
       }
     }
   }
@@ -234,10 +219,7 @@ class _PlaylistsPageState extends ConsumerState<PlaylistsPage> {
     final originalIds = fullPlaylists.map((p) => p.id).toList();
     if (_listEquals(playlistIds, originalIds)) {
       if (mounted) {
-        ResponsiveSnackBar.show(
-          context,
-          message: AppLocalizations.of(context).playlistAlreadySortedPlaylists,
-        );
+        ResponsiveSnackBar.show(context, message: '歌单已是该排序顺序');
       }
       return;
     }
@@ -246,14 +228,10 @@ class _PlaylistsPageState extends ConsumerState<PlaylistsPage> {
     final success = await notifier.reorderPlaylists(playlistIds);
 
     if (mounted) {
-      final l10n = AppLocalizations.of(context);
       if (success) {
-        ResponsiveSnackBar.showSuccess(
-          context,
-          message: l10n.playlistSortedByNumber,
-        );
+        ResponsiveSnackBar.showSuccess(context, message: '已按数字前缀排序');
       } else {
-        ResponsiveSnackBar.showError(context, message: l10n.playlistSortFailed);
+        ResponsiveSnackBar.showError(context, message: '排序失败');
       }
     }
   }
@@ -281,7 +259,6 @@ class _PlaylistsPageState extends ConsumerState<PlaylistsPage> {
   @override
   Widget build(BuildContext context) {
     final playlistsAsync = ref.watch(playlistListProvider(_selectedType));
-    final l10n = AppLocalizations.of(context);
 
     return Scaffold(
       appBar:
@@ -297,40 +274,29 @@ class _PlaylistsPageState extends ConsumerState<PlaylistsPage> {
                 onRefresh: () async {
                   ref.invalidate(playlistListProvider(_selectedType));
                 },
-                child: Center(
-                  child: ConstrainedBox(
-                    constraints: const BoxConstraints(maxWidth: 1200),
-                    child: CustomScrollView(
+                child: CustomScrollView(
                   controller: _scrollController,
                   slivers: [
                     // 类型筛选
                     SliverToBoxAdapter(
                       child: Padding(
-                        padding: EdgeInsets.symmetric(
-                          horizontal: context.responsive<double>(
-                            mobile: AppSpacing.md,
-                            tablet: AppSpacing.lg,
-                            desktop: AppSpacing.xl,
-                            tv: AppSpacing.xxl,
-                          ),
-                          vertical: AppSpacing.md,
-                        ),
+                        padding: const EdgeInsets.all(16),
                         child: SegmentedButton<String?>(
-                          segments: [
+                          segments: const [
                             ButtonSegment(
                               value: null,
-                              label: Text(l10n.filterAll),
-                              icon: const Icon(Icons.list),
+                              label: Text('全部'),
+                              icon: Icon(Icons.list),
                             ),
                             ButtonSegment(
                               value: AppConstants.playlistTypeNormal,
-                              label: Text(l10n.playlistTitle),
-                              icon: const Icon(Icons.queue_music),
+                              label: Text('歌单'),
+                              icon: Icon(Icons.queue_music),
                             ),
                             ButtonSegment(
                               value: AppConstants.playlistTypeRadio,
-                              label: Text(l10n.songTypeRadio),
-                              icon: const Icon(Icons.radio),
+                              label: Text('电台'),
+                              icon: Icon(Icons.radio),
                             ),
                           ],
                           selected: {_selectedType},
@@ -375,15 +341,12 @@ class _PlaylistsPageState extends ConsumerState<PlaylistsPage> {
                     ),
                   ],
                 ),
-                  ),
-                ),
               ),
     );
   }
 
   /// 构建加载更多指示器（含错误重试）
   Widget _buildLoadMoreIndicator(PaginatedPlaylistsState state) {
-    final l10n = AppLocalizations.of(context);
     if (state.loadMoreError != null) {
       return Padding(
         padding: const EdgeInsets.symmetric(vertical: 16),
@@ -395,7 +358,7 @@ class _PlaylistsPageState extends ConsumerState<PlaylistsPage> {
                         .read(playlistListProvider(_selectedType).notifier)
                         .loadMore(),
             icon: const Icon(Icons.refresh),
-            label: Text(l10n.playlistLoadMoreRetry),
+            label: const Text('加载更多失败，点击重试'),
           ),
         ),
       );
@@ -411,7 +374,7 @@ class _PlaylistsPageState extends ConsumerState<PlaylistsPage> {
         padding: const EdgeInsets.symmetric(vertical: 16),
         child: Center(
           child: Text(
-            l10n.playlistAllLoaded(state.items.length),
+            '— 已全部加载（${state.items.length}） —',
             style: Theme.of(context).textTheme.bodySmall?.copyWith(
               color: Theme.of(context).colorScheme.onSurfaceVariant,
             ),
@@ -425,10 +388,9 @@ class _PlaylistsPageState extends ConsumerState<PlaylistsPage> {
   AppBar _buildNormalAppBar() {
     final playlistsAsync = ref.watch(playlistListProvider(_selectedType));
     final playlists = playlistsAsync.value?.items ?? [];
-    final l10n = AppLocalizations.of(context);
 
     return AppBar(
-      title: Text(l10n.playlistTitle),
+      title: const Text('歌单'),
       actions: [
         // 视图模式切换按钮
         IconButton(
@@ -439,22 +401,16 @@ class _PlaylistsPageState extends ConsumerState<PlaylistsPage> {
           ),
           tooltip:
               ref.watch(playlistViewModeProvider) == PlaylistViewMode.grid
-                  ? l10n.playlistSwitchToListView
-                  : l10n.playlistSwitchToGridView,
+                  ? '切换到列表视图'
+                  : '切换到卡片视图',
           onPressed: () {
             ref.read(playlistViewModeProvider.notifier).toggleViewMode();
           },
         ),
-        // 多选模式按钮
-        IconButton(
-          icon: const Icon(Icons.checklist),
-          tooltip: l10n.playlistMultiSelect,
-          onPressed: _toggleSelectMode,
-        ),
         // 排序按钮（含自动排序选项）
         PopupMenuButton<String>(
           icon: const Icon(Icons.sort),
-          tooltip: l10n.playlistSort,
+          tooltip: '排序',
           onSelected: (value) {
             switch (value) {
               case 'name_asc':
@@ -469,77 +425,67 @@ class _PlaylistsPageState extends ConsumerState<PlaylistsPage> {
           },
           itemBuilder:
               (context) => [
-                PopupMenuItem(
+                const PopupMenuItem(
                   value: 'name_asc',
                   child: ListTile(
-                    leading: const Icon(Icons.sort_by_alpha),
-                    title: Text(l10n.playlistSortNameAsc),
+                    leading: Icon(Icons.sort_by_alpha),
+                    title: Text('按名称排序 A→Z'),
                     dense: true,
                     contentPadding: EdgeInsets.zero,
                   ),
                 ),
-                PopupMenuItem(
+                const PopupMenuItem(
                   value: 'name_desc',
                   child: ListTile(
-                    leading: const Icon(Icons.sort_by_alpha),
-                    title: Text(l10n.playlistSortNameDesc),
+                    leading: Icon(Icons.sort_by_alpha),
+                    title: Text('按名称排序 Z→A'),
                     dense: true,
                     contentPadding: EdgeInsets.zero,
                   ),
                 ),
-                PopupMenuItem(
+                const PopupMenuItem(
                   value: 'number_asc',
                   child: ListTile(
-                    leading: const Icon(Icons.format_list_numbered),
-                    title: Text(l10n.playlistSortNumberPrefix),
+                    leading: Icon(Icons.format_list_numbered),
+                    title: Text('按数字前缀排序'),
                     dense: true,
                     contentPadding: EdgeInsets.zero,
                   ),
                 ),
-                PopupMenuItem(
+                const PopupMenuItem(
                   value: 'manual',
                   child: ListTile(
-                    leading: const Icon(Icons.drag_handle),
-                    title: Text(l10n.playlistSortManual),
+                    leading: Icon(Icons.drag_handle),
+                    title: Text('手动排序'),
                     dense: true,
                     contentPadding: EdgeInsets.zero,
                   ),
                 ),
               ],
         ),
+        // 多选模式按钮
+        IconButton(
+          icon: const Icon(Icons.checklist),
+          tooltip: '多选',
+          onPressed: _toggleSelectMode,
+        ),
         // 更多菜单
         PopupMenuButton<String>(
           icon: const Icon(Icons.more_vert),
-          tooltip: l10n.playlistMore,
+          tooltip: '更多',
           onSelected: (value) {
             switch (value) {
               case 'create':
                 _showCreateDialog();
-              case 'toggle_hidden':
-                _toggleShowHidden();
             }
           },
           itemBuilder:
               (context) => [
-                PopupMenuItem(
+                const PopupMenuItem(
                   value: 'create',
                   child: ListTile(
-                    leading: const Icon(Icons.add),
-                    title: Text(l10n.playlistCreate),
-                    contentPadding: EdgeInsets.zero,
-                  ),
-                ),
-                PopupMenuItem(
-                  value: 'toggle_hidden',
-                  child: ListTile(
-                    leading: Icon(
-                      _showHidden
-                          ? Icons.visibility_off
-                          : Icons.visibility,
-                    ),
-                    title: Text(
-                      _showHidden ? l10n.playlistHideHidden : l10n.playlistShowHidden,
-                    ),
+                    leading: Icon(Icons.add),
+                    title: Text('创建歌单'),
                     contentPadding: EdgeInsets.zero,
                   ),
                 ),
@@ -550,17 +496,14 @@ class _PlaylistsPageState extends ConsumerState<PlaylistsPage> {
   }
 
   AppBar _buildSortAppBar() {
-    final l10n = AppLocalizations.of(context);
     return AppBar(
       leading: IconButton(
         icon: const Icon(Icons.close),
-        tooltip: l10n.commonCancel,
+        tooltip: '取消',
         onPressed: _cancelSortMode,
       ),
-      title: Text(l10n.playlistSortModeTitle),
-      actions: [
-        TextButton(onPressed: _exitSortMode, child: Text(l10n.playlistDone)),
-      ],
+      title: const Text('排序歌单'),
+      actions: [TextButton(onPressed: _exitSortMode, child: const Text('完成'))],
     );
   }
 
@@ -568,10 +511,9 @@ class _PlaylistsPageState extends ConsumerState<PlaylistsPage> {
   Widget _buildSortModeBody() {
     final colorScheme = Theme.of(context).colorScheme;
     final textTheme = Theme.of(context).textTheme;
-    final l10n = AppLocalizations.of(context);
 
     if (_sortablePlaylists.isEmpty) {
-      return Center(child: Text(l10n.noPlaylists));
+      return const Center(child: Text('暂无歌单'));
     }
 
     return ReorderableListView.builder(
@@ -580,6 +522,7 @@ class _PlaylistsPageState extends ConsumerState<PlaylistsPage> {
       onReorder: _onReorder,
       itemBuilder: (context, index) {
         final playlist = _sortablePlaylists[index];
+        final coverUrl = playlist.coverUrl;
         return Card(
           key: ValueKey(playlist.id),
           child: Padding(
@@ -605,34 +548,30 @@ class _PlaylistsPageState extends ConsumerState<PlaylistsPage> {
                     width: 48,
                     height: 48,
                     child:
-                        playlist.coverImageUrl != null
-                            ? ExcludeSemantics(
-                              child: CachedNetworkImage(
-                                imageUrl: UrlHelper.buildCoverUrl(
-                                  playlist.coverImageUrl!,
-                                ),
-                                fit: BoxFit.cover,
-                                placeholder:
-                                    (context, url) => Container(
-                                      color: colorScheme.surfaceContainerHighest,
-                                      child: Icon(
-                                        Icons.queue_music,
-                                        size: 24,
-                                        color: colorScheme.onSurfaceVariant
-                                            .withValues(alpha: 0.5),
-                                      ),
+                        coverUrl != null && coverUrl.isNotEmpty
+                            ? CachedNetworkImage(
+                              imageUrl: UrlHelper.buildCoverUrl(coverUrl),
+                              fit: BoxFit.cover,
+                              placeholder:
+                                  (context, url) => Container(
+                                    color: colorScheme.surfaceContainerHighest,
+                                    child: Icon(
+                                      Icons.queue_music,
+                                      size: 24,
+                                      color: colorScheme.onSurfaceVariant
+                                          .withValues(alpha: 0.5),
                                     ),
-                                errorWidget:
-                                    (context, url, error) => Container(
-                                      color: colorScheme.surfaceContainerHighest,
-                                      child: Icon(
-                                        Icons.queue_music,
-                                        size: 24,
-                                        color: colorScheme.onSurfaceVariant
-                                            .withValues(alpha: 0.5),
-                                      ),
+                                  ),
+                              errorWidget:
+                                  (context, url, error) => Container(
+                                    color: colorScheme.surfaceContainerHighest,
+                                    child: Icon(
+                                      Icons.queue_music,
+                                      size: 24,
+                                      color: colorScheme.onSurfaceVariant
+                                          .withValues(alpha: 0.5),
                                     ),
-                              ),
+                                  ),
                             )
                             : Container(
                               color: colorScheme.surfaceContainerHighest,
@@ -666,7 +605,7 @@ class _PlaylistsPageState extends ConsumerState<PlaylistsPage> {
                       ),
                       const SizedBox(height: 2),
                       Text(
-                        l10n.songsCount(playlist.songCount),
+                        '${playlist.songCount} 首歌曲',
                         style: textTheme.bodySmall?.copyWith(
                           color: colorScheme.onSurfaceVariant,
                         ),
@@ -693,14 +632,12 @@ class _PlaylistsPageState extends ConsumerState<PlaylistsPage> {
   AppBar _buildSelectionAppBar(
     AsyncValue<PaginatedPlaylistsState> playlistsAsync,
   ) {
-    final l10n = AppLocalizations.of(context);
     return AppBar(
       leading: IconButton(
         icon: const Icon(Icons.close),
-        tooltip: l10n.playlistExitMultiSelect,
         onPressed: _toggleSelectMode,
       ),
-      title: Text(l10n.playlistSelectedCount(_selectedPlaylistIds.length)),
+      title: Text('已选择 ${_selectedPlaylistIds.length} 个'),
       actions: [
         // 播放按钮
         TextButton.icon(
@@ -712,7 +649,7 @@ class _PlaylistsPageState extends ConsumerState<PlaylistsPage> {
                     : Theme.of(context).colorScheme.primary,
           ),
           label: Text(
-            l10n.playlistPlayCount(_selectedPlaylistIds.length),
+            '播放(${_selectedPlaylistIds.length})',
             style: TextStyle(
               color:
                   _selectedPlaylistIds.isEmpty
@@ -733,7 +670,7 @@ class _PlaylistsPageState extends ConsumerState<PlaylistsPage> {
                     : Theme.of(context).colorScheme.error,
           ),
           label: Text(
-            l10n.playlistDeleteCount(_selectedPlaylistIds.length),
+            '删除(${_selectedPlaylistIds.length})',
             style: TextStyle(
               color:
                   _selectedPlaylistIds.isEmpty
@@ -754,7 +691,7 @@ class _PlaylistsPageState extends ConsumerState<PlaylistsPage> {
               _selectAll(state.items);
             }
           },
-          child: Text(l10n.selectAll),
+          child: const Text('全选'),
         ),
       ],
     );
@@ -775,34 +712,20 @@ class _PlaylistsPageState extends ConsumerState<PlaylistsPage> {
   }
 
   Widget _buildGridView(BuildContext context, List<Playlist> playlists) {
-    final currentPlaylistId = ref.watch(sourcePlaylistIdProvider);
-    final isPlaying = ref.watch(isPlayingProvider);
     final crossAxisCount = context.responsive<int>(
       mobile: 2,
       tablet: 3,
       desktop: 4,
       tv: 5,
     );
-    final gridSpacing = context.responsive<double>(
-      mobile: AppSpacing.md,
-      tablet: AppSpacing.md,
-      desktop: AppSpacing.lg,
-      tv: AppSpacing.xl,
-    );
-    final horizontalPadding = context.responsive<double>(
-      mobile: AppSpacing.md,
-      tablet: AppSpacing.lg,
-      desktop: AppSpacing.xl,
-      tv: AppSpacing.xxl,
-    );
 
     return SliverPadding(
-      padding: EdgeInsets.symmetric(horizontal: horizontalPadding),
+      padding: const EdgeInsets.symmetric(horizontal: 16),
       sliver: SliverGrid(
         gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
           crossAxisCount: crossAxisCount,
-          mainAxisSpacing: gridSpacing,
-          crossAxisSpacing: gridSpacing,
+          mainAxisSpacing: 16,
+          crossAxisSpacing: 16,
           childAspectRatio: 0.7,
         ),
         delegate: SliverChildBuilderDelegate((context, index) {
@@ -813,20 +736,10 @@ class _PlaylistsPageState extends ConsumerState<PlaylistsPage> {
             onEdit: () => _showEditDialog(playlist),
             onDelete:
                 playlist.isBuiltIn ? null : () => _confirmDelete(playlist),
-            onToggleVisibility: () => _togglePlaylistVisibility(playlist),
             onPlayAll: () => _playAll(playlist),
-            onLongPress: () {
-              setState(() {
-                _isSelectionMode = true;
-                _selectedPlaylistIds.clear();
-              });
-              _togglePlaylistSelection(playlist);
-            },
             isSelectionMode: _isSelectionMode,
             isSelected: _selectedPlaylistIds.contains(playlist.id),
             onSelect: () => _togglePlaylistSelection(playlist),
-            isCurrentPlaylist: playlist.id == currentPlaylistId,
-            isPlaying: isPlaying,
           );
         }, childCount: playlists.length),
       ),
@@ -834,16 +747,8 @@ class _PlaylistsPageState extends ConsumerState<PlaylistsPage> {
   }
 
   Widget _buildListView(BuildContext context, List<Playlist> playlists) {
-    final currentPlaylistId = ref.watch(sourcePlaylistIdProvider);
-    final isPlaying = ref.watch(isPlayingProvider);
-    final horizontalPadding = context.responsive<double>(
-      mobile: AppSpacing.md,
-      tablet: AppSpacing.lg,
-      desktop: AppSpacing.xl,
-      tv: AppSpacing.xxl,
-    );
     return SliverPadding(
-      padding: EdgeInsets.symmetric(horizontal: horizontalPadding),
+      padding: const EdgeInsets.symmetric(horizontal: 16),
       sliver: SliverList(
         delegate: SliverChildBuilderDelegate((context, index) {
           final playlist = playlists[index];
@@ -853,20 +758,10 @@ class _PlaylistsPageState extends ConsumerState<PlaylistsPage> {
             onEdit: () => _showEditDialog(playlist),
             onDelete:
                 playlist.isBuiltIn ? null : () => _confirmDelete(playlist),
-            onToggleVisibility: () => _togglePlaylistVisibility(playlist),
             onPlayAll: () => _playAll(playlist),
-            onLongPress: () {
-              setState(() {
-                _isSelectionMode = true;
-                _selectedPlaylistIds.clear();
-              });
-              _togglePlaylistSelection(playlist);
-            },
             isSelectionMode: _isSelectionMode,
             isSelected: _selectedPlaylistIds.contains(playlist.id),
             onSelect: () => _togglePlaylistSelection(playlist),
-            isCurrentPlaylist: playlist.id == currentPlaylistId,
-            isPlaying: isPlaying,
           );
         }, childCount: playlists.length),
       ),
@@ -876,7 +771,6 @@ class _PlaylistsPageState extends ConsumerState<PlaylistsPage> {
   Widget _buildEmptyContent() {
     final colorScheme = Theme.of(context).colorScheme;
     final textTheme = Theme.of(context).textTheme;
-    final l10n = AppLocalizations.of(context);
 
     return Padding(
       padding: const EdgeInsets.all(64),
@@ -884,31 +778,23 @@ class _PlaylistsPageState extends ConsumerState<PlaylistsPage> {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Container(
-              width: 96,
-              height: 96,
-              decoration: BoxDecoration(
-                color: colorScheme.surfaceContainerHighest,
-                borderRadius: AppRadius.xlAll,
-              ),
-              child: Icon(
-                Icons.queue_music_outlined,
-                size: 48,
-                color: colorScheme.onSurfaceVariant.withValues(alpha: 0.5),
-              ),
+            Icon(
+              Icons.queue_music_outlined,
+              size: 64,
+              color: colorScheme.onSurfaceVariant.withValues(alpha: 0.5),
             ),
-            const SizedBox(height: 24),
+            const SizedBox(height: 16),
             Text(
-              l10n.noPlaylists,
+              '暂无歌单',
               style: textTheme.titleMedium?.copyWith(
                 color: colorScheme.onSurfaceVariant,
               ),
             ),
             const SizedBox(height: 8),
             Text(
-              l10n.playlistEmptyHint,
+              '点击右上角按钮创建歌单',
               style: textTheme.bodySmall?.copyWith(
-                color: colorScheme.onSurfaceVariant.withValues(alpha: 0.7),
+                color: colorScheme.onSurfaceVariant,
               ),
             ),
           ],
@@ -920,7 +806,6 @@ class _PlaylistsPageState extends ConsumerState<PlaylistsPage> {
   Widget _buildErrorContent(String error) {
     final colorScheme = Theme.of(context).colorScheme;
     final textTheme = Theme.of(context).textTheme;
-    final l10n = AppLocalizations.of(context);
 
     return Padding(
       padding: const EdgeInsets.all(32),
@@ -930,7 +815,7 @@ class _PlaylistsPageState extends ConsumerState<PlaylistsPage> {
           children: [
             Icon(Icons.error_outline, size: 64, color: colorScheme.error),
             const SizedBox(height: 16),
-            Text(l10n.commonLoadFailed, style: textTheme.titleMedium),
+            Text('加载失败', style: textTheme.titleMedium),
             const SizedBox(height: 8),
             Text(
               error,
@@ -944,7 +829,7 @@ class _PlaylistsPageState extends ConsumerState<PlaylistsPage> {
               onPressed:
                   () => ref.invalidate(playlistListProvider(_selectedType)),
               icon: const Icon(Icons.refresh),
-              label: Text(l10n.commonRetry),
+              label: const Text('重试'),
             ),
           ],
         ),
@@ -954,10 +839,9 @@ class _PlaylistsPageState extends ConsumerState<PlaylistsPage> {
 
   /// 显示创建歌单对话框
   Future<void> _showCreateDialog() async {
-    final l10n = AppLocalizations.of(context);
     final result = await showDialog<Map<String, dynamic>>(
       context: context,
-      builder: (context) => _PlaylistFormDialog(title: l10n.playlistCreate),
+      builder: (context) => const _PlaylistFormDialog(title: '创建歌单'),
     );
 
     if (result != null && mounted) {
@@ -969,21 +853,18 @@ class _PlaylistsPageState extends ConsumerState<PlaylistsPage> {
       );
 
       if (playlist != null && mounted) {
-        ResponsiveSnackBar.showSuccess(context, message: l10n.playlistCreated);
+        ResponsiveSnackBar.showSuccess(context, message: '歌单创建成功');
       }
     }
   }
 
   /// 显示编辑歌单对话框
   Future<void> _showEditDialog(Playlist playlist) async {
-    final l10n = AppLocalizations.of(context);
     final result = await showDialog<Map<String, dynamic>>(
       context: context,
       builder:
           (context) => _PlaylistFormDialog(
-            title: playlist.isBuiltIn
-                ? l10n.playlistEditCover
-                : l10n.playlistEditPlaylist,
+            title: playlist.isBuiltIn ? '修改封面' : '编辑歌单',
             initialName: playlist.name,
             initialDescription: playlist.description,
             initialType: playlist.type,
@@ -1001,7 +882,8 @@ class _PlaylistsPageState extends ConsumerState<PlaylistsPage> {
       // 处理封面
       final coverMode = result['coverMode'] as String?;
       final localFile = result['localFile'] as PlatformFile?;
-      final selectedCoverSongId = result['selectedCoverSongId'] as int?;
+      final selectedCoverPath = result['selectedCoverPath'] as String?;
+      final selectedCoverUrl = result['selectedCoverUrl'] as String?;
 
       if (coverMode == 'local' && localFile != null) {
         // 上传本地图片
@@ -1012,7 +894,7 @@ class _PlaylistsPageState extends ConsumerState<PlaylistsPage> {
           fileName: localFile.name,
         );
         if (uploadedPlaylist == null && mounted) {
-          ResponsiveSnackBar.showError(context, message: l10n.playlistCoverUploadFailed);
+          ResponsiveSnackBar.showError(context, message: '封面上传失败');
           return;
         }
         // 更新其他信息，同时传递封面信息防止被后端覆盖
@@ -1025,19 +907,20 @@ class _PlaylistsPageState extends ConsumerState<PlaylistsPage> {
         );
 
         if (updated != null && mounted) {
-          ResponsiveSnackBar.showSuccess(context, message: l10n.playlistUpdated);
+          ResponsiveSnackBar.showSuccess(context, message: '歌单更新成功');
         }
-      } else if (coverMode == 'song' && selectedCoverSongId != null) {
+      } else if (coverMode == 'song') {
         // 从歌曲选择的封面
         final updated = await notifier.updatePlaylist(
           playlist.id,
           name: result['name'] as String,
           description: result['description'] as String?,
-          coverSongId: selectedCoverSongId,
+          coverPath: selectedCoverPath ?? '',
+          coverUrl: selectedCoverUrl ?? '',
         );
 
         if (updated != null && mounted) {
-          ResponsiveSnackBar.showSuccess(context, message: l10n.playlistUpdated);
+          ResponsiveSnackBar.showSuccess(context, message: '歌单更新成功');
         }
       } else if (coverMode == 'clear') {
         // 清除封面
@@ -1050,7 +933,7 @@ class _PlaylistsPageState extends ConsumerState<PlaylistsPage> {
         );
 
         if (updated != null && mounted) {
-          ResponsiveSnackBar.showSuccess(context, message: l10n.playlistUpdated);
+          ResponsiveSnackBar.showSuccess(context, message: '歌单更新成功');
         }
       } else {
         // 未修改封面
@@ -1061,7 +944,7 @@ class _PlaylistsPageState extends ConsumerState<PlaylistsPage> {
         );
 
         if (updated != null && mounted) {
-          ResponsiveSnackBar.showSuccess(context, message: l10n.playlistUpdated);
+          ResponsiveSnackBar.showSuccess(context, message: '歌单更新成功');
         }
       }
     }
@@ -1072,24 +955,23 @@ class _PlaylistsPageState extends ConsumerState<PlaylistsPage> {
     final count = _selectedPlaylistIds.length;
     if (count == 0) return;
 
-    final l10n = AppLocalizations.of(context);
     final confirmed = await showDialog<bool>(
       context: context,
       builder:
           (context) => AlertDialog(
-            title: Text(l10n.playlistConfirmBatchDelete),
-            content: Text(l10n.playlistBatchDeleteConfirm(count)),
+            title: const Text('确认批量删除'),
+            content: Text('确定要删除选中的 $count 个歌单吗？此操作不可恢复。'),
             actions: [
               TextButton(
                 onPressed: () => Navigator.of(context).pop(false),
-                child: Text(l10n.commonCancel),
+                child: const Text('取消'),
               ),
               FilledButton(
                 onPressed: () => Navigator.of(context).pop(true),
                 style: FilledButton.styleFrom(
                   backgroundColor: Theme.of(context).colorScheme.error,
                 ),
-                child: Text(l10n.commonDelete),
+                child: const Text('删除'),
               ),
             ],
           ),
@@ -1103,12 +985,9 @@ class _PlaylistsPageState extends ConsumerState<PlaylistsPage> {
 
       if (mounted) {
         if (deleted > 0) {
-          ResponsiveSnackBar.showSuccess(
-            context,
-            message: l10n.playlistDeletedCount(deleted),
-          );
+          ResponsiveSnackBar.showSuccess(context, message: '已删除 $deleted 个歌单');
         } else {
-          ResponsiveSnackBar.showError(context, message: l10n.playlistDeleteFailed);
+          ResponsiveSnackBar.showError(context, message: '删除失败');
         }
         setState(() {
           _isSelectionMode = false;
@@ -1120,24 +999,23 @@ class _PlaylistsPageState extends ConsumerState<PlaylistsPage> {
 
   /// 确认删除歌单
   Future<void> _confirmDelete(Playlist playlist) async {
-    final l10n = AppLocalizations.of(context);
     final confirmed = await showDialog<bool>(
       context: context,
       builder:
           (context) => AlertDialog(
-            title: Text(l10n.playlistConfirmDelete),
-            content: Text(l10n.playlistDeleteConfirm(playlist.name)),
+            title: const Text('确认删除'),
+            content: Text('确定要删除歌单「${playlist.name}」吗？此操作不可恢复。'),
             actions: [
               TextButton(
                 onPressed: () => Navigator.of(context).pop(false),
-                child: Text(l10n.commonCancel),
+                child: const Text('取消'),
               ),
               FilledButton(
                 onPressed: () => Navigator.of(context).pop(true),
                 style: FilledButton.styleFrom(
                   backgroundColor: Theme.of(context).colorScheme.error,
                 ),
-                child: Text(l10n.commonDelete),
+                child: const Text('删除'),
               ),
             ],
           ),
@@ -1148,33 +1026,8 @@ class _PlaylistsPageState extends ConsumerState<PlaylistsPage> {
       final success = await notifier.deletePlaylist(playlist.id);
 
       if (success && mounted) {
-        ResponsiveSnackBar.showSuccess(context, message: l10n.playlistDeleted);
+        ResponsiveSnackBar.showSuccess(context, message: '歌单已删除');
       }
-    }
-  }
-
-  void _toggleShowHidden() {
-    setState(() {
-      _showHidden = !_showHidden;
-    });
-    ref
-        .read(playlistListProvider(_selectedType).notifier)
-        .setExcludeLabels(_showHidden ? 'none' : null);
-  }
-
-  Future<void> _togglePlaylistVisibility(Playlist playlist) async {
-    final notifier = ref.read(playlistNotifierProvider.notifier);
-    final hidden = !playlist.isHidden;
-    final success = await notifier.setPlaylistVisibility(
-      playlist.id,
-      hidden: hidden,
-    );
-    if (success && mounted) {
-      final l10n = AppLocalizations.of(context);
-      ResponsiveSnackBar.showSuccess(
-        context,
-        message: hidden ? l10n.playlistHidden : l10n.playlistUnhidden,
-      );
     }
   }
 
@@ -1185,15 +1038,14 @@ class _PlaylistsPageState extends ConsumerState<PlaylistsPage> {
         .read(playerStateProvider.notifier)
         .playMultiplePlaylistsById(ids);
     if (!mounted) return;
-    final l10n = AppLocalizations.of(context);
     if (total < 0) {
-      ResponsiveSnackBar.showError(context, message: l10n.playlistPlayFailed);
+      ResponsiveSnackBar.showError(context, message: '播放失败');
     } else if (total == 0) {
-      ResponsiveSnackBar.show(context, message: l10n.playlistEmpty);
+      ResponsiveSnackBar.show(context, message: '歌单为空');
     } else {
       ResponsiveSnackBar.show(
         context,
-        message: l10n.playlistPlayingMultiple(ids.length),
+        message: '正在播放 ${ids.length} 个歌单',
       );
     }
   }
@@ -1204,16 +1056,12 @@ class _PlaylistsPageState extends ConsumerState<PlaylistsPage> {
         .read(playerStateProvider.notifier)
         .playPlaylistById(playlist.id);
     if (!mounted) return;
-    final l10n = AppLocalizations.of(context);
     if (total < 0) {
-      ResponsiveSnackBar.showError(context, message: l10n.playlistPlayFailed);
+      ResponsiveSnackBar.showError(context, message: '播放失败');
     } else if (total == 0) {
-      ResponsiveSnackBar.show(context, message: l10n.playlistEmpty);
+      ResponsiveSnackBar.show(context, message: '歌单为空');
     } else {
-      ResponsiveSnackBar.show(
-        context,
-        message: l10n.playlistPlayingCount(total),
-      );
+      ResponsiveSnackBar.show(context, message: '播放全部 $total 首歌曲');
     }
   }
 }
@@ -1253,8 +1101,8 @@ class _PlaylistFormDialogState extends State<_PlaylistFormDialog> {
   /// 封面选择模式（仅编辑模式）
   String? _coverMode;
   PlatformFile? _localFile;
+  String? _selectedCoverPath;
   String? _selectedCoverUrl;
-  int? _selectedCoverSongId;
 
   @override
   void initState() {
@@ -1301,10 +1149,7 @@ class _PlaylistFormDialogState extends State<_PlaylistFormDialog> {
       }
     } catch (e) {
       if (mounted) {
-        ResponsiveSnackBar.showError(
-          context,
-          message: AppLocalizations.of(context).playlistPickImageFailed('$e'),
-        );
+        ResponsiveSnackBar.showError(context, message: '选择图片失败: $e');
       }
     }
   }
@@ -1315,8 +1160,8 @@ class _PlaylistFormDialogState extends State<_PlaylistFormDialog> {
     final result = await showSongCoverPicker(context, widget.playlistId!);
     if (result != null) {
       setState(() {
-        _selectedCoverSongId = result['songId'] as int?;
-        _selectedCoverUrl = result['coverUrl'] as String?;
+        _selectedCoverPath = result['coverPath'];
+        _selectedCoverUrl = result['coverUrl'];
         _coverMode = 'song';
         _localFile = null;
       });
@@ -1328,15 +1173,14 @@ class _PlaylistFormDialogState extends State<_PlaylistFormDialog> {
     setState(() {
       _coverMode = 'clear';
       _localFile = null;
+      _selectedCoverPath = null;
       _selectedCoverUrl = null;
-      _selectedCoverSongId = null;
     });
   }
 
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
-    final l10n = AppLocalizations.of(context);
     final hasCover =
         _coverMode != 'clear' &&
         (_coverMode == 'local' ||
@@ -1375,12 +1219,12 @@ class _PlaylistFormDialogState extends State<_PlaylistFormDialog> {
                       OutlinedButton.icon(
                         onPressed: _pickLocalImage,
                         icon: const Icon(Icons.upload, size: 18),
-                        label: Text(l10n.playlistUploadImage),
+                        label: const Text('上传图片'),
                       ),
                       OutlinedButton.icon(
                         onPressed: _pickFromSongs,
                         icon: const Icon(Icons.music_note, size: 18),
-                        label: Text(l10n.playlistPickFromSongs),
+                        label: const Text('从歌曲选择'),
                       ),
                       if (hasCover)
                         TextButton.icon(
@@ -1391,7 +1235,7 @@ class _PlaylistFormDialogState extends State<_PlaylistFormDialog> {
                             color: colorScheme.error,
                           ),
                           label: Text(
-                            l10n.playlistClear,
+                            '清除',
                             style: TextStyle(color: colorScheme.error),
                           ),
                         ),
@@ -1402,14 +1246,14 @@ class _PlaylistFormDialogState extends State<_PlaylistFormDialog> {
                 // 歌单名称
                 TextFormField(
                   controller: _nameController,
-                  decoration: InputDecoration(
-                    labelText: l10n.playlistNameLabel,
-                    hintText: l10n.playlistNameHint,
-                    border: const OutlineInputBorder(),
+                  decoration: const InputDecoration(
+                    labelText: '歌单名称',
+                    hintText: '请输入歌单名称',
+                    border: OutlineInputBorder(),
                   ),
                   validator: (value) {
                     if (value == null || value.trim().isEmpty) {
-                      return l10n.playlistNameRequired;
+                      return '请输入歌单名称';
                     }
                     return null;
                   },
@@ -1420,10 +1264,10 @@ class _PlaylistFormDialogState extends State<_PlaylistFormDialog> {
                 // 歌单描述
                 TextFormField(
                   controller: _descriptionController,
-                  decoration: InputDecoration(
-                    labelText: l10n.playlistDescLabel,
-                    hintText: l10n.playlistDescHint,
-                    border: const OutlineInputBorder(),
+                  decoration: const InputDecoration(
+                    labelText: '歌单描述',
+                    hintText: '请输入歌单描述（可选）',
+                    border: OutlineInputBorder(),
                   ),
                   maxLines: 3,
                   enabled: !widget.isBuiltIn,
@@ -1432,16 +1276,16 @@ class _PlaylistFormDialogState extends State<_PlaylistFormDialog> {
                 // 歌单类型（仅创建时可选）
                 if (!widget.isEdit)
                   SegmentedButton<String>(
-                    segments: [
+                    segments: const [
                       ButtonSegment(
                         value: AppConstants.playlistTypeNormal,
-                        label: Text(l10n.playlistTypeNormalOption),
-                        icon: const Icon(Icons.queue_music),
+                        label: Text('普通歌单'),
+                        icon: Icon(Icons.queue_music),
                       ),
                       ButtonSegment(
                         value: AppConstants.playlistTypeRadio,
-                        label: Text(l10n.playlistTypeRadioOption),
-                        icon: const Icon(Icons.radio),
+                        label: Text('电台歌单'),
+                        icon: Icon(Icons.radio),
                       ),
                     ],
                     selected: {_type},
@@ -1459,9 +1303,9 @@ class _PlaylistFormDialogState extends State<_PlaylistFormDialog> {
       actions: [
         TextButton(
           onPressed: () => Navigator.of(context).pop(),
-          child: Text(l10n.commonCancel),
+          child: const Text('取消'),
         ),
-        FilledButton(onPressed: _submit, child: Text(l10n.playlistOk)),
+        FilledButton(onPressed: _submit, child: const Text('确定')),
       ],
     );
   }
@@ -1479,15 +1323,13 @@ class _PlaylistFormDialogState extends State<_PlaylistFormDialog> {
     // 网络图片预览
     final previewUrl = _previewCoverUrl;
     if (previewUrl != null) {
-      return ExcludeSemantics(
-        child: CachedNetworkImage(
-          imageUrl: UrlHelper.buildCoverUrl(previewUrl),
-          fit: BoxFit.cover,
-          placeholder:
-              (context, url) =>
-                  const Center(child: CircularProgressIndicator(strokeWidth: 2)),
-          errorWidget: (context, url, error) => _buildPlaceholder(colorScheme),
-        ),
+      return CachedNetworkImage(
+        imageUrl: UrlHelper.buildCoverUrl(previewUrl),
+        fit: BoxFit.cover,
+        placeholder:
+            (context, url) =>
+                const Center(child: CircularProgressIndicator(strokeWidth: 2)),
+        errorWidget: (context, url, error) => _buildPlaceholder(colorScheme),
       );
     }
 
@@ -1520,9 +1362,8 @@ class _PlaylistFormDialogState extends State<_PlaylistFormDialog> {
       if (widget.isEdit) {
         result['coverMode'] = _coverMode;
         result['localFile'] = _localFile;
+        result['selectedCoverPath'] = _selectedCoverPath;
         result['selectedCoverUrl'] = _selectedCoverUrl;
-        result['selectedCoverSongId'] = _selectedCoverSongId;
-        result['selectedCoverSongId'] = _selectedCoverSongId;
       }
 
       Navigator.of(context).pop(result);

--- a/lib/features/playlist/presentation/widgets/playlist_card.dart
+++ b/lib/features/playlist/presentation/widgets/playlist_card.dart
@@ -1,9 +1,7 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 
-import '../../../../core/theme/app_dimensions.dart';
 import '../../../../core/utils/url_helper.dart';
-import '../../../../l10n/app_localizations.dart';
 import '../../domain/playlist.dart';
 
 /// 歌单卡片组件
@@ -12,14 +10,10 @@ class PlaylistCard extends StatelessWidget {
   final VoidCallback? onTap;
   final VoidCallback? onEdit;
   final VoidCallback? onDelete;
-  final VoidCallback? onToggleVisibility;
   final VoidCallback? onPlayAll;
-  final VoidCallback? onLongPress;
   final bool isSelectionMode;
   final bool isSelected;
   final VoidCallback? onSelect;
-  final bool isCurrentPlaylist;
-  final bool isPlaying;
 
   const PlaylistCard({
     super.key,
@@ -27,260 +21,188 @@ class PlaylistCard extends StatelessWidget {
     this.onTap,
     this.onEdit,
     this.onDelete,
-    this.onToggleVisibility,
     this.onPlayAll,
-    this.onLongPress,
     this.isSelectionMode = false,
     this.isSelected = false,
     this.onSelect,
-    this.isCurrentPlaylist = false,
-    this.isPlaying = false,
   });
 
   @override
   Widget build(BuildContext context) {
+    final coverUrl = playlist.coverUrl;
     final colorScheme = Theme.of(context).colorScheme;
     final textTheme = Theme.of(context).textTheme;
-    final l10n = AppLocalizations.of(context);
 
-    return Container(
-      decoration: BoxDecoration(
-        borderRadius: AppRadius.lgAll,
-        boxShadow: AppShadows.light,
-      ),
-      child: Card(
-        clipBehavior: Clip.antiAlias,
-        shape:
-            (isSelectionMode && isSelected) || isCurrentPlaylist
-                ? RoundedRectangleBorder(
-                  borderRadius: AppRadius.lgAll,
-                  side: BorderSide(color: colorScheme.primary, width: 2),
-                )
-                : RoundedRectangleBorder(borderRadius: AppRadius.lgAll),
-        child: InkWell(
-          onTap: isSelectionMode ? onSelect : onTap,
-          onLongPress: isSelectionMode ? null : onLongPress,
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              // 方形封面区域
-              AspectRatio(
-                aspectRatio: 1,
-                child: Stack(
-                  fit: StackFit.expand,
-                  children: [
-                    // 封面图
-                    playlist.coverImageUrl != null
-                        ? ExcludeSemantics(
-                          child: CachedNetworkImage(
-                            imageUrl: UrlHelper.buildCoverUrl(
-                              playlist.coverImageUrl!,
-                            ),
-                            fit: BoxFit.cover,
-                            placeholder:
-                                (context, url) => _buildPlaceholder(colorScheme),
-                            errorWidget:
-                                (context, url, error) =>
-                                    _buildPlaceholder(colorScheme),
-                          ),
-                        )
-                        : _buildPlaceholder(colorScheme),
+    return Card(
+      clipBehavior: Clip.antiAlias,
+      shape:
+          isSelectionMode && isSelected
+              ? RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(12),
+                side: BorderSide(color: colorScheme.primary, width: 2),
+              )
+              : null,
+      child: InkWell(
+        onTap: isSelectionMode ? onSelect : onTap,
+        onLongPress: isSelectionMode ? null : _showContextMenu(context),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // 方形封面区域
+            AspectRatio(
+              aspectRatio: 1,
+              child: Stack(
+                fit: StackFit.expand,
+                children: [
+                  // 封面图
+                  coverUrl != null && coverUrl.isNotEmpty
+                      ? CachedNetworkImage(
+                        imageUrl: UrlHelper.buildCoverUrl(coverUrl),
+                        fit: BoxFit.cover,
+                        placeholder:
+                            (context, url) => _buildPlaceholder(colorScheme),
+                        errorWidget:
+                            (context, url, error) =>
+                                _buildPlaceholder(colorScheme),
+                      )
+                      : _buildPlaceholder(colorScheme),
 
-                    // 底部渐变遮罩
+                  // 播放全部按钮（右下角）
+                  if (onPlayAll != null)
                     Positioned(
-                      left: 0,
-                      right: 0,
-                      bottom: 0,
-                      height: 48,
-                      child: DecoratedBox(
-                        decoration: BoxDecoration(
-                          gradient: LinearGradient(
-                            begin: Alignment.topCenter,
-                            end: Alignment.bottomCenter,
-                            colors: [
-                              Colors.transparent,
-                              Colors.black.withValues(alpha: 0.3),
-                            ],
+                      right: 8,
+                      bottom: 8,
+                      child: Material(
+                        color: colorScheme.primary,
+                        shape: const CircleBorder(),
+                        elevation: 4,
+                        child: InkWell(
+                          onTap: onPlayAll,
+                          customBorder: const CircleBorder(),
+                          child: Padding(
+                            padding: const EdgeInsets.all(8),
+                            child: Icon(
+                              Icons.play_arrow,
+                              color: colorScheme.onPrimary,
+                              size: 24,
+                            ),
                           ),
                         ),
                       ),
                     ),
 
-                    // 正在播放指示器
-                    if (isCurrentPlaylist && isPlaying)
-                      Positioned.fill(
-                        child: Container(
-                          color: Colors.black54,
-                          child: Center(
-                            child: Icon(
-                              Icons.equalizer_rounded,
-                              size: 32,
-                              color: colorScheme.primary,
-                            ),
+                  // 多选模式下显示 Checkbox（左上角）
+                  if (isSelectionMode)
+                    Positioned(
+                      left: 8,
+                      top: 8,
+                      child: Container(
+                        decoration: BoxDecoration(
+                          color: colorScheme.surface.withValues(alpha: 0.8),
+                          borderRadius: BorderRadius.circular(4),
+                        ),
+                        child: Checkbox(
+                          value: isSelected,
+                          onChanged: (_) => onSelect?.call(),
+                        ),
+                      ),
+                    )
+                  // 类型标签（左上角）
+                  else if (playlist.type == 'radio')
+                    Positioned(
+                      left: 8,
+                      top: 8,
+                      child: Container(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 8,
+                          vertical: 4,
+                        ),
+                        decoration: BoxDecoration(
+                          color: colorScheme.secondary,
+                          borderRadius: BorderRadius.circular(4),
+                        ),
+                        child: Text(
+                          '电台',
+                          style: textTheme.labelSmall?.copyWith(
+                            color: colorScheme.onSecondary,
                           ),
                         ),
                       ),
-
-                    // 播放全部按钮（右下角）
-                    if (onPlayAll != null)
-                      Positioned(
-                        right: 8,
-                        bottom: 8,
-                        child: Semantics(
-                          button: true,
-                          label: l10n.playlistPlayAll,
-                          child: Tooltip(
-                            message: l10n.playlistPlayAll,
-                            child: Material(
-                              color: colorScheme.primary,
-                              shape: const CircleBorder(),
-                              elevation: 4,
-                              child: InkWell(
-                                onTap: onPlayAll,
-                                customBorder: const CircleBorder(),
-                                child: Padding(
-                                  padding: const EdgeInsets.all(8),
-                                  child: Icon(
-                                    Icons.play_arrow,
-                                    color: colorScheme.onPrimary,
-                                    size: 24,
-                                  ),
-                                ),
-                              ),
-                            ),
-                          ),
-                        ),
-                      ),
-
-                    // 多选模式下显示 Checkbox（左上角）
-                    if (isSelectionMode)
-                      Positioned(
-                        left: 8,
-                        top: 8,
-                        child: Container(
-                          decoration: BoxDecoration(
-                            color: colorScheme.surface.withValues(alpha: 0.8),
-                            borderRadius: BorderRadius.circular(4),
-                          ),
-                          child: Checkbox(
-                            value: isSelected,
-                            onChanged: (_) => onSelect?.call(),
-                          ),
-                        ),
-                      )
-                    // 类型标签（左上角）
-                    else if (playlist.type == 'radio')
-                      Positioned(
-                        left: 8,
-                        top: 8,
-                        child: Container(
-                          padding: const EdgeInsets.symmetric(
-                            horizontal: 8,
-                            vertical: 4,
-                          ),
-                          decoration: BoxDecoration(
-                            color: colorScheme.secondary,
-                            borderRadius: BorderRadius.circular(AppRadius.sm),
-                          ),
-                          child: Text(
-                            l10n.songTypeRadio,
-                            style: textTheme.labelSmall?.copyWith(
-                              color: colorScheme.onSecondary,
-                            ),
-                          ),
-                        ),
-                      ),
-
-                    // 更多按钮（右上角，非多选模式下显示）
-                    if (!isSelectionMode && (onEdit != null || onDelete != null))
-                      Positioned(
-                        right: 4,
-                        top: 4,
-                        child: Material(
-                          color: colorScheme.surface.withValues(alpha: 0.7),
-                          shape: const CircleBorder(),
-                          clipBehavior: Clip.antiAlias,
-                          child: _buildMoreButton(context),
-                        ),
-                      ),
-                  ],
-                ),
+                    ),
+                ],
               ),
+            ),
 
-              // 歌单信息
-              Expanded(
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
-                  child: LayoutBuilder(
-                    builder: (context, constraints) {
-                      final maxH = constraints.maxHeight;
-                      // 根据可用高度决定显示内容，避免溢出
-                      // titleSmall ~20px, bodySmall ~16px, label ~22px, spacing 2px
-                      // 歌曲数量始终显示，基础高度: name ~20 + spacing 2 + songCount ~16 = 38
-                      final hasDesc = playlist.description?.isNotEmpty == true;
-                      final hasLabels = playlist.labels.isNotEmpty;
-                      final showDesc = hasDesc && maxH >= 58;
-                      final showLabels =
-                          hasLabels && maxH >= (showDesc ? 82 : 62);
+            // 歌单信息
+            Expanded(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                child: LayoutBuilder(
+                  builder: (context, constraints) {
+                    final maxH = constraints.maxHeight;
+                    // 根据可用高度决定显示内容，避免溢出
+                    // titleSmall ~20px, bodySmall ~16px, label ~22px, spacing 2px
+                    // 歌曲数量始终显示，基础高度: name ~20 + spacing 2 + songCount ~16 = 38
+                    final hasDesc = playlist.description?.isNotEmpty == true;
+                    final hasLabels = playlist.labels.isNotEmpty;
+                    final showDesc = hasDesc && maxH >= 58;
+                    final showLabels =
+                        hasLabels && maxH >= (showDesc ? 82 : 62);
 
-                      return Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          // 歌单名称
-                          Text(
-                            playlist.name,
-                            style: textTheme.titleSmall?.copyWith(
-                              fontWeight: FontWeight.w600,
-                              color: isCurrentPlaylist
-                                  ? colorScheme.primary
-                                  : null,
-                            ),
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
+                    return Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        // 歌单名称
+                        Text(
+                          playlist.name,
+                          style: textTheme.titleSmall?.copyWith(
+                            fontWeight: FontWeight.w600,
                           ),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                        const SizedBox(height: 2),
+                        // 歌曲数量
+                        Text(
+                          '${playlist.songCount} 首歌曲',
+                          style: textTheme.bodySmall?.copyWith(
+                            color: colorScheme.onSurfaceVariant,
+                          ),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                        if (showDesc) ...[
                           const SizedBox(height: 2),
-                          // 歌曲数量
+                          // 歌单描述
                           Text(
-                            l10n.songsCount(playlist.songCount),
+                            playlist.description!,
                             style: textTheme.bodySmall?.copyWith(
                               color: colorScheme.onSurfaceVariant,
                             ),
                             maxLines: 1,
                             overflow: TextOverflow.ellipsis,
                           ),
-                          if (showDesc) ...[
-                            const SizedBox(height: 2),
-                            // 歌单描述
-                            Text(
-                              playlist.description!,
-                              style: textTheme.bodySmall?.copyWith(
-                                color: colorScheme.onSurfaceVariant,
-                              ),
-                              maxLines: 1,
-                              overflow: TextOverflow.ellipsis,
-                            ),
-                          ],
-                          if (showLabels) ...[
-                            const SizedBox(height: 2),
-                            // 标签
-                            Wrap(
-                              spacing: 4,
-                              runSpacing: 2,
-                              children:
-                                  playlist.labels.map((label) {
-                                    return _buildLabel(context, label);
-                                  }).toList(),
-                            ),
-                          ],
                         ],
-                      );
-                    },
-                  ),
+                        if (showLabels) ...[
+                          const SizedBox(height: 2),
+                          // 标签
+                          Wrap(
+                            spacing: 4,
+                            runSpacing: 2,
+                            children:
+                                playlist.labels.map((label) {
+                                  return _buildLabel(context, label);
+                                }).toList(),
+                          ),
+                        ],
+                      ],
+                    );
+                  },
                 ),
               ),
-            ],
-          ),
+            ),
+          ],
         ),
       ),
     );
@@ -302,23 +224,18 @@ class PlaylistCard extends StatelessWidget {
   Widget _buildLabel(BuildContext context, String label) {
     final colorScheme = Theme.of(context).colorScheme;
     final textTheme = Theme.of(context).textTheme;
-    final l10n = AppLocalizations.of(context);
 
     String displayLabel;
     Color backgroundColor;
 
     switch (label) {
       case 'built_in':
-        displayLabel = l10n.playlistLabelBuiltIn;
+        displayLabel = '内置';
         backgroundColor = colorScheme.primaryContainer;
         break;
       case 'auto_created':
-        displayLabel = l10n.playlistLabelAuto;
+        displayLabel = '自动';
         backgroundColor = colorScheme.secondaryContainer;
-        break;
-      case 'hidden':
-        displayLabel = l10n.playlistLabelHidden;
-        backgroundColor = colorScheme.errorContainer;
         break;
       default:
         displayLabel = label;
@@ -340,69 +257,53 @@ class PlaylistCard extends StatelessWidget {
     );
   }
 
-  Widget _buildMoreButton(BuildContext context) {
-    final l10n = AppLocalizations.of(context);
-    return PopupMenuButton<String>(
-      icon: Icon(
-        Icons.more_vert,
-        size: 20,
-        color: Theme.of(context).colorScheme.onSurface,
-      ),
-      padding: EdgeInsets.zero,
-      constraints: const BoxConstraints(minWidth: 32, minHeight: 32),
-      tooltip: l10n.playlistMoreActions,
-      onSelected: (value) {
-        switch (value) {
-          case 'edit':
-            onEdit?.call();
-          case 'delete':
-            onDelete?.call();
-          case 'toggle_visibility':
-            onToggleVisibility?.call();
-        }
-      },
-      itemBuilder: (context) => [
-        if (onEdit != null)
-          PopupMenuItem(
-            value: 'edit',
-            child: ListTile(
-              leading: const Icon(Icons.edit),
-              title: Text(l10n.playlistEditAction),
-              dense: true,
-              contentPadding: EdgeInsets.zero,
-            ),
-          ),
-        if (onToggleVisibility != null && !playlist.isBuiltIn)
-          PopupMenuItem(
-            value: 'toggle_visibility',
-            child: ListTile(
-              leading: Icon(
-                playlist.isHidden
-                    ? Icons.visibility
-                    : Icons.visibility_off,
+  VoidCallback? _showContextMenu(BuildContext context) {
+    if (onEdit == null && onDelete == null) return null;
+
+    return () {
+      final RenderBox? renderBox = context.findRenderObject() as RenderBox?;
+      if (renderBox == null) return;
+
+      final position = renderBox.localToGlobal(Offset.zero);
+      final size = renderBox.size;
+
+      showMenu(
+        context: context,
+        position: RelativeRect.fromLTRB(
+          position.dx,
+          position.dy + size.height / 2,
+          position.dx + size.width,
+          position.dy + size.height,
+        ),
+        items: [
+          if (onEdit != null)
+            PopupMenuItem(
+              onTap: onEdit,
+              child: const ListTile(
+                leading: Icon(Icons.edit),
+                title: Text('编辑'),
+                dense: true,
+                contentPadding: EdgeInsets.zero,
               ),
-              title: Text(playlist.isHidden ? l10n.playlistUnhide : l10n.playlistHide),
-              dense: true,
-              contentPadding: EdgeInsets.zero,
             ),
-          ),
-        if (onDelete != null && !playlist.isBuiltIn)
-          PopupMenuItem(
-            value: 'delete',
-            child: ListTile(
-              leading: Icon(
-                Icons.delete,
-                color: Theme.of(context).colorScheme.error,
+          if (onDelete != null && !playlist.isBuiltIn)
+            PopupMenuItem(
+              onTap: onDelete,
+              child: ListTile(
+                leading: Icon(
+                  Icons.delete,
+                  color: Theme.of(context).colorScheme.error,
+                ),
+                title: Text(
+                  '删除',
+                  style: TextStyle(color: Theme.of(context).colorScheme.error),
+                ),
+                dense: true,
+                contentPadding: EdgeInsets.zero,
               ),
-              title: Text(
-                l10n.commonDelete,
-                style: TextStyle(color: Theme.of(context).colorScheme.error),
-              ),
-              dense: true,
-              contentPadding: EdgeInsets.zero,
             ),
-          ),
-      ],
-    );
+        ],
+      );
+    };
   }
 }

--- a/lib/features/playlist/presentation/widgets/playlist_list_item.dart
+++ b/lib/features/playlist/presentation/widgets/playlist_list_item.dart
@@ -1,9 +1,7 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 
-import '../../../../core/theme/app_dimensions.dart';
 import '../../../../core/utils/url_helper.dart';
-import '../../../../l10n/app_localizations.dart';
 import '../../domain/playlist.dart';
 
 /// 歌单列表项组件（列表视图）
@@ -12,14 +10,10 @@ class PlaylistListItem extends StatelessWidget {
   final VoidCallback? onTap;
   final VoidCallback? onEdit;
   final VoidCallback? onDelete;
-  final VoidCallback? onToggleVisibility;
   final VoidCallback? onPlayAll;
-  final VoidCallback? onLongPress;
   final bool isSelectionMode;
   final bool isSelected;
   final VoidCallback? onSelect;
-  final bool isCurrentPlaylist;
-  final bool isPlaying;
 
   const PlaylistListItem({
     super.key,
@@ -27,36 +21,32 @@ class PlaylistListItem extends StatelessWidget {
     this.onTap,
     this.onEdit,
     this.onDelete,
-    this.onToggleVisibility,
     this.onPlayAll,
-    this.onLongPress,
     this.isSelectionMode = false,
     this.isSelected = false,
     this.onSelect,
-    this.isCurrentPlaylist = false,
-    this.isPlaying = false,
   });
 
   @override
   Widget build(BuildContext context) {
+    final coverUrl = playlist.coverUrl;
     final colorScheme = Theme.of(context).colorScheme;
     final textTheme = Theme.of(context).textTheme;
-    final l10n = AppLocalizations.of(context);
 
     return Card(
       clipBehavior: Clip.antiAlias,
       shape:
-          (isSelectionMode && isSelected) || isCurrentPlaylist
+          isSelectionMode && isSelected
               ? RoundedRectangleBorder(
-                borderRadius: AppRadius.mdAll,
+                borderRadius: BorderRadius.circular(12),
                 side: BorderSide(color: colorScheme.primary, width: 2),
               )
-              : RoundedRectangleBorder(borderRadius: AppRadius.mdAll),
+              : null,
       child: InkWell(
         onTap: isSelectionMode ? onSelect : onTap,
-        onLongPress: isSelectionMode ? null : onLongPress,
+        onLongPress: isSelectionMode ? null : _showContextMenu(context),
         child: Padding(
-          padding: const EdgeInsets.all(10),
+          padding: const EdgeInsets.all(8),
           child: Row(
             children: [
               // 多选模式下显示 Checkbox
@@ -70,42 +60,23 @@ class PlaylistListItem extends StatelessWidget {
                 ),
               // 左侧：方形封面 56x56
               ClipRRect(
-                borderRadius: AppRadius.smAll,
+                borderRadius: BorderRadius.circular(8),
                 child: SizedBox(
                   width: 56,
                   height: 56,
-                  child: Stack(
-                    fit: StackFit.expand,
-                    children: [
-                      playlist.coverImageUrl != null
-                          ? ExcludeSemantics(
-                            child: CachedNetworkImage(
-                              imageUrl: UrlHelper.buildCoverUrl(
-                                playlist.coverImageUrl!,
-                              ),
-                              fit: BoxFit.cover,
-                              placeholder:
-                                  (context, url) =>
-                                      _buildPlaceholder(colorScheme),
-                              errorWidget:
-                                  (context, url, error) =>
-                                      _buildPlaceholder(colorScheme),
-                            ),
+                  child:
+                      coverUrl != null && coverUrl.isNotEmpty
+                          ? CachedNetworkImage(
+                            imageUrl: UrlHelper.buildCoverUrl(coverUrl),
+                            fit: BoxFit.cover,
+                            placeholder:
+                                (context, url) =>
+                                    _buildPlaceholder(colorScheme),
+                            errorWidget:
+                                (context, url, error) =>
+                                    _buildPlaceholder(colorScheme),
                           )
                           : _buildPlaceholder(colorScheme),
-                      if (isCurrentPlaylist && isPlaying)
-                        Container(
-                          color: Colors.black54,
-                          child: Center(
-                            child: Icon(
-                              Icons.equalizer_rounded,
-                              size: 24,
-                              color: colorScheme.primary,
-                            ),
-                          ),
-                        ),
-                    ],
-                  ),
                 ),
               ),
               const SizedBox(width: 12),
@@ -124,9 +95,6 @@ class PlaylistListItem extends StatelessWidget {
                             playlist.name,
                             style: textTheme.titleSmall?.copyWith(
                               fontWeight: FontWeight.bold,
-                              color: isCurrentPlaylist
-                                  ? colorScheme.primary
-                                  : null,
                             ),
                             maxLines: 1,
                             overflow: TextOverflow.ellipsis,
@@ -141,10 +109,10 @@ class PlaylistListItem extends StatelessWidget {
                             ),
                             decoration: BoxDecoration(
                               color: colorScheme.secondary,
-                              borderRadius: BorderRadius.circular(AppRadius.sm),
+                              borderRadius: BorderRadius.circular(4),
                             ),
                             child: Text(
-                              l10n.songTypeRadio,
+                              '电台',
                               style: textTheme.labelSmall?.copyWith(
                                 color: colorScheme.onSecondary,
                                 fontSize: 10,
@@ -158,7 +126,7 @@ class PlaylistListItem extends StatelessWidget {
 
                     // 第二行：歌曲数量 · 描述
                     Text(
-                      _buildSubtitle(l10n),
+                      _buildSubtitle(),
                       style: textTheme.bodySmall?.copyWith(
                         color: colorScheme.onSurfaceVariant,
                       ),
@@ -188,12 +156,12 @@ class PlaylistListItem extends StatelessWidget {
                   IconButton(
                     onPressed: onPlayAll,
                     icon: const Icon(Icons.play_arrow),
-                    tooltip: l10n.playlistPlayAll,
+                    tooltip: '播放全部',
                   ),
                 IconButton(
                   onPressed: _showMoreMenu(context),
                   icon: const Icon(Icons.more_vert),
-                  tooltip: l10n.playlistMoreActions,
+                  tooltip: '更多操作',
                 ),
               ],
             ],
@@ -204,8 +172,8 @@ class PlaylistListItem extends StatelessWidget {
   }
 
   /// 构建副标题：歌曲数量 · 描述
-  String _buildSubtitle(AppLocalizations l10n) {
-    final parts = <String>[l10n.songsCount(playlist.songCount)];
+  String _buildSubtitle() {
+    final parts = <String>['${playlist.songCount} 首歌曲'];
     if (playlist.description?.isNotEmpty == true) {
       parts.add(playlist.description!);
     }
@@ -228,23 +196,18 @@ class PlaylistListItem extends StatelessWidget {
   Widget _buildLabel(BuildContext context, String label) {
     final colorScheme = Theme.of(context).colorScheme;
     final textTheme = Theme.of(context).textTheme;
-    final l10n = AppLocalizations.of(context);
 
     String displayLabel;
     Color backgroundColor;
 
     switch (label) {
       case 'built_in':
-        displayLabel = l10n.playlistLabelBuiltIn;
+        displayLabel = '内置';
         backgroundColor = colorScheme.primaryContainer;
         break;
       case 'auto_created':
-        displayLabel = l10n.playlistLabelAuto;
+        displayLabel = '自动';
         backgroundColor = colorScheme.secondaryContainer;
-        break;
-      case 'hidden':
-        displayLabel = l10n.playlistLabelHidden;
-        backgroundColor = colorScheme.errorContainer;
         break;
       default:
         displayLabel = label;
@@ -290,30 +253,39 @@ class PlaylistListItem extends StatelessWidget {
     };
   }
 
+  /// 长按显示上下文菜单
+  VoidCallback? _showContextMenu(BuildContext context) {
+    if (onEdit == null && onDelete == null) return null;
+
+    return () {
+      final RenderBox? renderBox = context.findRenderObject() as RenderBox?;
+      if (renderBox == null) return;
+
+      final position = renderBox.localToGlobal(Offset.zero);
+      final size = renderBox.size;
+
+      showMenu(
+        context: context,
+        position: RelativeRect.fromLTRB(
+          position.dx,
+          position.dy + size.height / 2,
+          position.dx + size.width,
+          position.dy + size.height,
+        ),
+        items: _buildMenuItems(context),
+      );
+    };
+  }
+
   /// 构建菜单项
   List<PopupMenuEntry<void>> _buildMenuItems(BuildContext context) {
-    final l10n = AppLocalizations.of(context);
     return [
       if (onEdit != null)
         PopupMenuItem(
           onTap: onEdit,
-          child: ListTile(
-            leading: const Icon(Icons.edit),
-            title: Text(l10n.playlistEditAction),
-            dense: true,
-            contentPadding: EdgeInsets.zero,
-          ),
-        ),
-      if (onToggleVisibility != null && !playlist.isBuiltIn)
-        PopupMenuItem(
-          onTap: onToggleVisibility,
-          child: ListTile(
-            leading: Icon(
-              playlist.isHidden
-                  ? Icons.visibility
-                  : Icons.visibility_off,
-            ),
-            title: Text(playlist.isHidden ? l10n.playlistUnhide : l10n.playlistHide),
+          child: const ListTile(
+            leading: Icon(Icons.edit),
+            title: Text('编辑'),
             dense: true,
             contentPadding: EdgeInsets.zero,
           ),
@@ -327,7 +299,7 @@ class PlaylistListItem extends StatelessWidget {
               color: Theme.of(context).colorScheme.error,
             ),
             title: Text(
-              l10n.commonDelete,
+              '删除',
               style: TextStyle(color: Theme.of(context).colorScheme.error),
             ),
             dense: true,

--- a/lib/features/playlist/presentation/widgets/song_cover_picker_modal.dart
+++ b/lib/features/playlist/presentation/widgets/song_cover_picker_modal.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../core/utils/url_helper.dart';
-import '../../../../l10n/app_localizations.dart';
 import '../../../../shared/models/song.dart';
 import '../providers/playlist_provider.dart';
 
@@ -17,7 +16,6 @@ class SongCoverPickerModal extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final songsAsync = ref.watch(playlistSongsProvider(playlistId));
     final colorScheme = Theme.of(context).colorScheme;
-    final l10n = AppLocalizations.of(context);
 
     return Container(
       height: MediaQuery.of(context).size.height * 0.7,
@@ -45,17 +43,13 @@ class SongCoverPickerModal extends ConsumerWidget {
             padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
             child: Row(
               children: [
-                Text(
-                  l10n.playlistPickCoverTitle,
-                  style: const TextStyle(
-                    fontSize: 18,
-                    fontWeight: FontWeight.bold,
-                  ),
+                const Text(
+                  '选择歌曲封面',
+                  style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
                 ),
                 const Spacer(),
                 IconButton(
                   icon: const Icon(Icons.close),
-                  tooltip: l10n.playlistClose,
                   onPressed: () => Navigator.of(context).pop(),
                 ),
               ],
@@ -71,7 +65,7 @@ class SongCoverPickerModal extends ConsumerWidget {
                 // 过滤有封面的歌曲
                 final songsWithCover =
                     state.items.where((song) {
-                      return song.coverUrl != null && song.coverUrl!.isNotEmpty;
+                      return song.coverUrl != null && coverUrl.isNotEmpty && song.coverUrl!.isNotEmpty;
                     }).toList();
 
                 if (songsWithCover.isEmpty && !state.hasMore) {
@@ -86,7 +80,7 @@ class SongCoverPickerModal extends ConsumerWidget {
                         ),
                         const SizedBox(height: 16),
                         Text(
-                          l10n.playlistNoCoveredSongs,
+                          '歌单中没有带封面的歌曲',
                           style: TextStyle(color: colorScheme.onSurfaceVariant),
                         ),
                       ],
@@ -129,10 +123,7 @@ class SongCoverPickerModal extends ConsumerWidget {
                               onTap: () {
                                 Navigator.of(
                                   context,
-                                ).pop({
-                                  'songId': song.id,
-                                  'coverUrl': song.coverUrl,
-                                });
+                                ).pop({'coverUrl': song.coverUrl});
                               },
                             );
                           }, childCount: songsWithCover.length),
@@ -163,7 +154,7 @@ class SongCoverPickerModal extends ConsumerWidget {
                         ),
                         const SizedBox(height: 16),
                         Text(
-                          l10n.commonLoadFailed,
+                          '加载失败',
                           style: TextStyle(color: colorScheme.error),
                         ),
                       ],
@@ -184,7 +175,6 @@ class SongCoverPickerModal extends ConsumerWidget {
     bool noCoverYet,
   ) {
     final theme = Theme.of(context);
-    final l10n = AppLocalizations.of(context);
     if (state.isLoadingMore) {
       return const Padding(
         padding: EdgeInsets.symmetric(vertical: 16),
@@ -208,7 +198,7 @@ class SongCoverPickerModal extends ConsumerWidget {
                         .read(playlistSongsProvider(playlistId).notifier)
                         .loadMore(),
             icon: const Icon(Icons.refresh, size: 16),
-            label: Text(l10n.playlistLoadRetry),
+            label: const Text('加载失败，点击重试'),
           ),
         ),
       );
@@ -226,7 +216,7 @@ class SongCoverPickerModal extends ConsumerWidget {
                           .read(playlistSongsProvider(playlistId).notifier)
                           .loadMore(),
               icon: const Icon(Icons.expand_more, size: 16),
-              label: Text(l10n.playlistNoCoverLoadMore),
+              label: const Text('当前页无带封面歌曲，加载更多'),
             ),
           ),
         );
@@ -238,7 +228,7 @@ class SongCoverPickerModal extends ConsumerWidget {
         padding: const EdgeInsets.symmetric(vertical: 12),
         child: Center(
           child: Text(
-            l10n.playlistAllLoadedSimple,
+            '— 已加载全部 —',
             style: theme.textTheme.bodySmall?.copyWith(
               color: theme.colorScheme.onSurfaceVariant,
             ),
@@ -262,64 +252,58 @@ class _CoverGridItem extends StatelessWidget {
     final colorScheme = Theme.of(context).colorScheme;
     final coverUrl = song.coverUrl;
 
-    return Semantics(
-      button: true,
-      label: AppLocalizations.of(context).playlistSelectThisCover,
-      child: InkWell(
-        onTap: onTap,
-        borderRadius: BorderRadius.circular(8),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            // 封面图片
-            Expanded(
-              child: ClipRRect(
-                borderRadius: BorderRadius.circular(8),
-                child:
-                    coverUrl != null
-                        ? ExcludeSemantics(
-                          child: CachedNetworkImage(
-                            imageUrl: UrlHelper.buildCoverUrl(coverUrl),
-                            fit: BoxFit.cover,
-                            placeholder:
-                                (context, url) => Container(
-                                  color: colorScheme.surfaceContainerHighest,
-                                  child: const Center(
-                                    child: CircularProgressIndicator(
-                                      strokeWidth: 2,
-                                    ),
-                                  ),
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(8),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          // 封面图片
+          Expanded(
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(8),
+              child:
+                  coverUrl != null && coverUrl.isNotEmpty
+                      ? CachedNetworkImage(
+                        imageUrl: UrlHelper.buildCoverUrl(coverUrl),
+                        fit: BoxFit.cover,
+                        placeholder:
+                            (context, url) => Container(
+                              color: colorScheme.surfaceContainerHighest,
+                              child: const Center(
+                                child: CircularProgressIndicator(
+                                  strokeWidth: 2,
                                 ),
-                            errorWidget:
-                                (context, url, error) => Container(
-                                  color: colorScheme.surfaceContainerHighest,
-                                  child: Icon(
-                                    Icons.music_note,
-                                    color: colorScheme.onSurfaceVariant,
-                                  ),
-                                ),
-                          ),
-                        )
-                        : Container(
-                          color: colorScheme.surfaceContainerHighest,
-                          child: Icon(
-                            Icons.music_note,
-                            color: colorScheme.onSurfaceVariant,
-                          ),
+                              ),
+                            ),
+                        errorWidget:
+                            (context, url, error) => Container(
+                              color: colorScheme.surfaceContainerHighest,
+                              child: Icon(
+                                Icons.music_note,
+                                color: colorScheme.onSurfaceVariant,
+                              ),
+                            ),
+                      )
+                      : Container(
+                        color: colorScheme.surfaceContainerHighest,
+                        child: Icon(
+                          Icons.music_note,
+                          color: colorScheme.onSurfaceVariant,
                         ),
-              ),
+                      ),
             ),
-            const SizedBox(height: 4),
-            // 歌曲标题
-            Text(
-              song.title,
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-              style: Theme.of(context).textTheme.bodySmall,
-              textAlign: TextAlign.center,
-            ),
-          ],
-        ),
+          ),
+          const SizedBox(height: 4),
+          // 歌曲标题
+          Text(
+            song.title,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: Theme.of(context).textTheme.bodySmall,
+            textAlign: TextAlign.center,
+          ),
+        ],
       ),
     );
   }
@@ -327,12 +311,12 @@ class _CoverGridItem extends StatelessWidget {
 
 /// 显示歌曲封面选择弹窗的便捷方法
 ///
-/// 返回选中的封面信息 Map，包含 'songId'(int) 和 'coverUrl'(String?)，取消返回 null
-Future<Map<String, dynamic>?> showSongCoverPicker(
+/// 返回选中的封面信息 Map，包含 'coverPath' 和 'coverUrl'，取消返回 null
+Future<Map<String, String?>?> showSongCoverPicker(
   BuildContext context,
   int playlistId,
 ) {
-  return showModalBottomSheet<Map<String, dynamic>>(
+  return showModalBottomSheet<Map<String, String?>>(
     context: context,
     isScrollControlled: true,
     useSafeArea: true,


### PR DESCRIPTION
## 问题

全屏播放器（Desktop/Mobile/TV）在 coverUrl 为空字符串 `''` 而非 `null` 时，尝试加载无效 URL，导致封面显示为灰色占位符（音符图标），而播放条和播放信息卡片能正常显示封面。

## 修复

全局统一 `coverUrl` 检查逻辑，从 `coverUrl != null` 改为 `coverUrl != null && coverUrl.isNotEmpty`，覆盖 14 个文件：

**播放器：**
- `desktop_full_player.dart` — 桌面全屏播放器（封面 + 背景模糊）
- `mobile_player.dart` — 移动端全屏播放器
- `tv_player.dart` — TV 全屏播放器
- `desktop_player.dart` — 桌面播放条

**列表/队列：**
- `queue_page.dart` — 播放队列
- `playlist_drawer.dart` — 播放列表抽屉

**歌单/首页：**
- `playlist_carousel.dart` — 首页轮播
- `song_list_tile.dart` — 歌曲列表项
- `playlists_page.dart` — 歌单页
- `playlist_detail_page.dart` — 歌单详情页（2 处）
- `playlist_card.dart` — 歌单卡片
- `playlist_list_item.dart` — 歌单列表项
- `song_cover_picker_modal.dart` — 封面选择器

**Provider：**
- `player_provider.dart` — 播放器状态 Provider

## 根因

`mini_player.dart` 已经正确使用 `coverUrl != null && coverUrl.isNotEmpty`，但其他组件只检查了 `!= null`。当歌曲通过 `/api/v1/songs/remote` 导入（如 lxmusic `/topone` multiMode 返回空 URL 的元数据），`cover_url` 字段可能是空字符串而非 null，导致全屏播放器尝试加载空 URL 失败后显示占位符。