### PR TITLE
feat(android): declare Android Auto media app support

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -48,11 +48,19 @@
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />
-        <!-- audio_service 服务 -->
+        <!-- Android Auto: declara la app como app de medios (aparece en el cajon y permite abrirla) -->
+        <meta-data
+            android:name="com.google.android.gms.car.application"
+            android:resource="@xml/automotive_app_desc" />
+        <!-- audio_service 服务 (Android Auto: requiere intent-filter MediaBrowserService) -->
         <service
             android:name="com.ryanheise.audioservice.AudioService"
             android:foregroundServiceType="mediaPlayback"
-            android:exported="true">
+            android:exported="true"
+            tools:ignore="Instantiatable">
+            <intent-filter>
+                <action android:name="android.media.browse.MediaBrowserService" />
+            </intent-filter>
         </service>
         <receiver
             android:name="com.ryanheise.audioservice.MediaButtonReceiver"

--- a/android/app/src/main/res/xml/automotive_app_desc.xml
+++ b/android/app/src/main/res/xml/automotive_app_desc.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Android Auto / Android Automotive: declara la categoria de app de medios -->
+<automotiveApp>
+    <uses name="media"/>
+</automotiveApp>


### PR DESCRIPTION
## Summary
Enables **Android Auto** media app integration (phone projection):
- Added `<meta-data android:name="com.google.android.gms.car.application">` pointing to `@xml/automotive_app_desc` (category `media`).
- New `android/app/src/main/res/xml/automotive_app_desc.xml`.
- Added `android.media.browse.MediaBrowserService` intent-filter to `com.ryanheise.audioservice.AudioService`.

## Motivation
Without these declarations Android Auto detects the audio session (music shows in the bottom bar) but the app is **not listed in the app drawer** and the system blocks opening it as a media app.

## How to test
1. Install the APK on the phone and connect to Android Auto.
2. Verify Songloft appears in the app drawer and can be opened (Settings → Apps for Android Auto if not immediately visible).
